### PR TITLE
Use `c_char` not `i8` for error message string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ unsafe impl Sync for AzureCredentials {}
 pub struct Response {
     result: CResult,
     length: usize,
-    error_message: *mut i8,
+    error_message: *mut c_char,
 }
 
 unsafe impl Send for Response {}


### PR DESCRIPTION
To try to fix aarch64-linux-gnu build, where we saw:
```
    Compiling object_store_ffi v0.1.0 (/workspace/srcdir/object_store_ffi)
    error[E0308]: mismatched types
    --> src/lib.rs:145:30
    |
    145 |         self.error_message = c_string.into_raw();
    |         ------------------   ^^^^^^^^^^^^^^^^^^^ expected `*mut i8`, found `*mut u8`
    |         |
    |         expected due to the type of this binding
    |
    = note: expected raw pointer `*mut i8`
    found raw pointer `*mut u8`
```
https://github.com/JuliaPackaging/Yggdrasil/pull/7920#issuecomment-1881610189