### PR TITLE
Dynamic configuration API and S3 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,8 @@ dependencies = [
  "object_store",
  "once_cell",
  "reqwest",
+ "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 futures-util = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "trust-dns"] }
-object_store = { version = "0.8", features = ["azure"] }
+object_store = { version = "0.8", features = ["azure", "aws"] }
 thiserror = "1"
 anyhow = "1"
 once_cell = "1.18"
@@ -26,3 +26,5 @@ async-channel = "1.9.0"
 crossbeam-queue = "0.3.8"
 moka = { version = "0.12.0", features = ["future"] }
 url = "2.4"
+serde = "1"
+serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,18 @@
 use futures_util::StreamExt;
+use object_store::RetryConfig;
 use once_cell::sync::Lazy;
 use once_cell::sync::OnceCell;
 use tokio::runtime::Runtime;
-use std::ffi::CStr;
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::ffi::{c_char, c_void};
 use std::sync::Arc;
+use anyhow::anyhow;
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 
 use object_store::{path::Path, ObjectStore};
-use object_store::azure::MicrosoftAzureBuilder;  // TODO aws::AmazonS3Builder
 
 use moka::future::Cache;
 
@@ -45,8 +46,8 @@ pub enum CResult {
 // The types used for our internal dispatch mechanism, for dispatching Julia requests
 // to our worker task.
 enum Request {
-    Get(Path, &'static mut [u8], &'static AzureCredentials, &'static mut Response, Notifier),
-    Put(Path, &'static [u8], &'static AzureCredentials, &'static mut Response, Notifier)
+    Get(Path, &'static mut [u8], &'static Config, &'static mut Response, Notifier),
+    Put(Path, &'static [u8], &'static Config, &'static mut Response, Notifier)
 }
 
 unsafe impl Send for Request {}
@@ -74,11 +75,108 @@ impl Notifier {
 unsafe impl Send for Notifier {}
 
 #[repr(C)]
-pub struct AzureCredentials {
-    account: *const c_char,
-    container: *const c_char,
-    key: *const c_char,
-    host: *const c_char,
+pub struct Config {
+    config_string: *const c_char
+}
+
+unsafe impl Send for Config {}
+unsafe impl Sync for Config {}
+
+impl Config {
+    fn get_hash(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        let config_string = self.as_str();
+        hasher.write(config_string.as_bytes());
+        hasher.finish()
+    }
+
+    fn as_str(&self) -> &str {
+        let config_string = unsafe { std::ffi::CStr::from_ptr(self.config_string) };
+        config_string.to_str().expect("julia strings are valid utf8")
+    }
+
+    fn as_json(&self) -> anyhow::Result<serde_json::Value> {
+        Ok(serde_json::from_str(self.as_str())?)
+    }
+}
+
+pub async fn dyn_connect(config: &Config) -> anyhow::Result<Arc<dyn ObjectStore>> {
+    let value = config.as_json()
+            .map_err(|e| anyhow!("failed to parse json serialized config: {}", e))?;
+
+    let mut map: HashMap<String, String> = serde_json::from_value(value)
+        .map_err(|e| anyhow!("config must be a json serialized object: {}", e))?;
+
+    let url = map.remove("url")
+        .ok_or(anyhow!("config object must have a key named 'url'"))?;
+
+    let url = url::Url::parse(&url)
+        .map_err(|e| anyhow!("failed to parse `url`: {}", e))?;
+
+    if let Some(v) = map.remove("azurite_host") {
+        let mut azurite_host = url::Url::parse(&v)
+            .map_err(|e| anyhow!("failed to parse azurite_host: {}", e))?;
+        azurite_host.set_path("");
+        std::env::set_var("AZURITE_BLOB_STORAGE_URL", azurite_host.as_str());
+        map.insert("allow_invalid_certificates".into(), "true".into());
+        map.insert("azure_storage_use_emulator".into(), "true".into());
+    }
+
+    if let Some(v) = map.remove("minio_host") {
+        let mut minio_host = url::Url::parse(&v)
+            .map_err(|e| anyhow!("failed to parse minio_host: {}", e))?;
+        minio_host.set_path("");
+        // std::env::set_var("AZURITE_BLOB_STORAGE_URL", azurite_host.as_str());
+        map.insert("allow_http".into(), "true".into());
+        map.insert("aws_endpoint".into(), minio_host.as_str().trim_end_matches('/').to_string());
+        tracing::warn!("aws endpoint: {}", map["aws_endpoint"]);
+    }
+
+    let mut retry_config = RetryConfig::default();
+    if let Some(value) = map.remove("max_retries") {
+        retry_config.max_retries = value.parse()
+            .map_err(|e| anyhow!("failed to parse max_retries: {}", e))?;
+    }
+    if let Some(value) = map.remove("retry_timeout_secs") {
+        retry_config.retry_timeout = std::time::Duration::from_secs(value.parse()
+            .map_err(|e| anyhow!("failed to parse retry_timeout_sec: {}", e))?
+        );
+    }
+
+    let client: Arc<dyn ObjectStore> = match url.scheme() {
+        "s3" => {
+            let mut builder = object_store::aws::AmazonS3Builder::default()
+                .with_url(url)
+                .with_retry(retry_config);
+            for (key, value) in map {
+                builder = builder.with_config(key.parse()?, value);
+            }
+            Arc::new(builder.build()?)
+        }
+        "az" | "azure" => {
+            let mut builder = object_store::azure::MicrosoftAzureBuilder::default()
+                .with_url(url)
+                .with_retry(retry_config);
+            for (key, value) in map {
+                builder = builder.with_config(key.parse()?, value);
+            }
+            Arc::new(builder.build()?)
+        }
+        _ => unimplemented!("unknown url scheme")
+    };
+    // let (store, _) = object_store::parse_url_opts(&url, pairs)?;
+
+    // let client: Arc<dyn ObjectStore> = Arc::new(store);
+
+    // let ping_path: Path = "_this_file_does_not_exist".try_into().unwrap();
+    // match client.get(&ping_path).await {
+    //     Ok(_) | Err(object_store::Error::NotFound { .. }) => {},
+    //     Err(e) => {
+    //         return Err(anyhow!("failed to check store client connection: {}", e));
+    //     }
+    // }
+
+    Ok(client)
 }
 
 #[repr(C)]
@@ -86,39 +184,6 @@ pub struct GlobalConfigOptions {
     max_retries: usize,
     retry_timeout_sec: u64,
 }
-
-impl AzureCredentials {
-    fn get_hash(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        let (account, container, key, host) = self.as_cstr_tuple();
-        hasher.write(account.to_bytes());
-        hasher.write(container.to_bytes());
-        hasher.write(key.to_bytes());
-        hasher.write(host.to_bytes());
-        hasher.finish()
-    }
-
-    fn as_cstr_tuple(&self) -> (&CStr, &CStr, &CStr, &CStr) {
-        let account = unsafe { std::ffi::CStr::from_ptr(self.account) };
-        let container = unsafe { std::ffi::CStr::from_ptr(self.container) };
-        let key = unsafe { std::ffi::CStr::from_ptr(self.key) };
-        let host = unsafe { std::ffi::CStr::from_ptr(self.host) };
-        (account, container, key, host)
-    }
-
-    fn to_string_tuple(&self) -> (String, String, String, String) {
-        let (account, container, key, host) = self.as_cstr_tuple();
-        (
-            account.to_str().unwrap().to_string(),
-            container.to_str().unwrap().to_string(),
-            key.to_str().unwrap().to_string(),
-            host.to_str().unwrap().to_string()
-        )
-    }
-}
-
-unsafe impl Send for AzureCredentials {}
-unsafe impl Sync for AzureCredentials {}
 
 // The type used to give Julia the result of an async request. It will be allocated
 // by Julia as part of the request and filled in by Rust.
@@ -138,57 +203,12 @@ impl Response {
         self.error_message = std::ptr::null_mut();
     }
 
-    fn _error(&mut self, error_message: impl AsRef<str>) {
-        self.result = CResult::Error;
-        self.length = 0;
-        let c_string = CString::new(error_message.as_ref()).expect("should not have nulls");
-        self.error_message = c_string.into_raw();
-    }
-
     fn from_error(&mut self, error: impl std::fmt::Display) {
         self.result = CResult::Error;
         self.length = 0;
         let c_string = CString::new(format!("{}", error)).expect("should not have nulls");
         self.error_message = c_string.into_raw();
     }
-}
-
-async fn connect(credentials: &AzureCredentials) -> anyhow::Result<Arc<dyn ObjectStore>> {
-    let (account, container, key, host) = credentials.to_string_tuple();
-    let max_retries = CONFIG.get().unwrap().max_retries;
-    let retry_timeout = std::time::Duration::from_secs(CONFIG.get().unwrap().retry_timeout_sec);
-    let mut azure = MicrosoftAzureBuilder::new()
-        .with_account(account)
-        .with_container_name(container)
-        .with_access_key(key)
-        .with_retry(object_store::RetryConfig {
-            max_retries: max_retries,
-            retry_timeout: retry_timeout,
-            ..Default::default()
-        })
-        .with_client_options(object_store::ClientOptions::new()
-            .with_timeout(std::time::Duration::from_secs(20))
-            .with_connect_timeout(std::time::Duration::from_secs(10))
-        );
-
-    if host.len() > 0 {
-        tracing::debug!("host = {}", host);
-        let mut url = url::Url::parse(&host)?;
-        url.set_path("");
-        std::env::set_var("AZURITE_BLOB_STORAGE_URL", url.as_str());
-        azure = azure.with_allow_http(true)
-            .with_use_emulator(true)
-            .with_client_options(object_store::ClientOptions::new()
-                .with_timeout(std::time::Duration::from_secs(20))
-                .with_connect_timeout(std::time::Duration::from_secs(10))
-                .with_allow_invalid_certificates(true)
-            );
-    }
-    let azure = azure.build()?;
-
-    let client: Arc<dyn ObjectStore> = Arc::new(azure);
-
-    Ok(client)
 }
 
 #[no_mangle]
@@ -209,8 +229,8 @@ pub extern "C" fn start(config: GlobalConfigOptions) -> CResult {
         rx.map(|req| {
             async {
                 match req {
-                    Request::Get(p, slice, credentials, response, notifier) => {
-                        let client = match CLIENTS.try_get_with(credentials.get_hash(), connect(credentials)).await {
+                    Request::Get(p, slice, config, response, notifier) => {
+                        let client = match CLIENTS.try_get_with(config.get_hash(), dyn_connect(config)).await {
                             Ok(client) => client,
                             Err(e) => {
                                 response.from_error(e);
@@ -229,7 +249,6 @@ pub extern "C" fn start(config: GlobalConfigOptions) -> CResult {
                                 }
                                 tokio::spawn(async move {
                                     let mut received_bytes = 0;
-                                    let mut failed = false;
                                     for result in chunks {
                                         let chunk = match result {
                                             Ok(c) => c,
@@ -240,17 +259,15 @@ pub extern "C" fn start(config: GlobalConfigOptions) -> CResult {
                                         let len = chunk.len();
 
                                         if received_bytes + len > slice.len() {
-                                            response._error("Supplied buffer was too small");
-                                            failed = true;
-                                            break;
+                                            response.from_error("Supplied buffer was too small");
+                                            notifier.notify();
+                                            return;
                                         }
 
                                         slice[received_bytes..(received_bytes + len)].copy_from_slice(&chunk);
                                         received_bytes += len;
                                     }
-                                    if !failed {
-                                        response.success(received_bytes);
-                                    }
+                                    response.success(received_bytes);
                                     notifier.notify();
                                 });
                             }
@@ -262,8 +279,8 @@ pub extern "C" fn start(config: GlobalConfigOptions) -> CResult {
                             }
                         }
                     }
-                    Request::Put(p, slice, credentials, response, notifier) => {
-                        let client = match CLIENTS.try_get_with(credentials.get_hash(), connect(credentials)).await {
+                    Request::Put(p, slice, config, response, notifier) => {
+                        let client = match CLIENTS.try_get_with(config.get_hash(), dyn_connect(config)).await {
                             Ok(client) => client,
                             Err(e) => {
                                 response.from_error(e);
@@ -294,11 +311,11 @@ pub extern "C" fn start(config: GlobalConfigOptions) -> CResult {
 }
 
 #[no_mangle]
-pub extern "C" fn perform_get(
+pub extern "C" fn get(
     path: *const c_char,
     buffer: *mut u8,
     size: usize,
-    credentials: *const AzureCredentials,
+    config: *const Config,
     response: *mut Response,
     handle: *const c_void
 ) -> CResult {
@@ -307,11 +324,11 @@ pub extern "C" fn perform_get(
     let path = unsafe { std::ffi::CStr::from_ptr(path) };
     let path: Path = path.to_str().expect("invalid utf8").try_into().unwrap();
     let slice = unsafe { std::slice::from_raw_parts_mut(buffer, size) };
-    let credentials = unsafe { & (*credentials) };
+    let config = unsafe { & (*config) };
     let notifier = Notifier { handle };
     match SQ.get() {
         Some(sq) => {
-            match sq.try_send(Request::Get(path, slice, credentials, response, notifier)) {
+            match sq.try_send(Request::Get(path, slice, config, response, notifier)) {
                 Ok(_) => CResult::Ok,
                 Err(async_channel::TrySendError::Full(_)) => {
                     CResult::Backoff
@@ -328,11 +345,11 @@ pub extern "C" fn perform_get(
 }
 
 #[no_mangle]
-pub extern "C" fn perform_put(
+pub extern "C" fn put(
     path: *const c_char,
     buffer: *const u8,
     size: usize,
-    credentials: *const AzureCredentials,
+    config: *const Config,
     response: *mut Response,
     handle: *const c_void
 ) -> CResult {
@@ -341,11 +358,11 @@ pub extern "C" fn perform_put(
     let path = unsafe { std::ffi::CStr::from_ptr(path) };
     let path: Path = path.to_str().expect("invalid utf8").try_into().unwrap();
     let slice = unsafe { std::slice::from_raw_parts(buffer, size) };
-    let credentials = unsafe { & (*credentials) };
+    let config = unsafe { & (*config) };
     let notifier = Notifier { handle };
     match SQ.get() {
         Some(sq) => {
-            match sq.try_send(Request::Put(path, slice, credentials, response, notifier)) {
+            match sq.try_send(Request::Put(path, slice, config, response, notifier)) {
                 Ok(_) => CResult::Ok,
                 Err(async_channel::TrySendError::Full(_)) => {
                     CResult::Backoff


### PR DESCRIPTION
Changes the API to use the JSON serialized dynamic config enabling support for both Azure and AWS through the same `get` and `put` functions.