### PR TITLE
Add support for Snowflake Stages and SNOWFLAKE_FULL encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.1+3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1338,7 @@ checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,13 +95,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -447,7 +447,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -524,6 +524,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,7 +603,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1231,7 +1246,9 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-compression",
+ "async-trait",
  "backoff",
+ "base64",
  "bytes",
  "criterion",
  "crossbeam-queue",
@@ -1242,17 +1259,22 @@ dependencies = [
  "moka",
  "object_store",
  "once_cell",
+ "openssl",
  "pin-project",
+ "rand",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1268,10 +1290,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -1337,7 +1397,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1366,9 +1426,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1453,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1759,22 +1819,22 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1785,6 +1845,16 @@ checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -1893,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.40"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1937,7 +2007,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2001,7 +2071,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2075,7 +2145,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2175,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
@@ -2187,6 +2257,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2240,7 +2316,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
 
@@ -2274,7 +2350,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.10.2"
-source = "git+https://github.com/andrebsguedes/arrow-rs.git?branch=unsigned-payload-and-azure-list-offset#5f3bf4e235194ab818e67d2a69e6695970af5b63"
+source = "git+https://github.com/andrebsguedes/arrow-rs.git?tag=v0.10.2-beta1#3e15b9a308e29479bc33e4f06855227d93bf88a6"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,7 +113,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -439,6 +451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,7 +465,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -603,7 +621,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -705,6 +723,9 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -1114,6 +1135,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "indexmap 2.1.0",
+ "metrics",
+ "num_cpus",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -1256,11 +1315,14 @@ dependencies = [
  "flume",
  "futures-util",
  "hyper",
+ "metrics",
+ "metrics-util",
  "moka",
  "object_store",
  "once_cell",
  "openssl",
  "pin-project",
+ "quanta",
  "rand",
  "regex",
  "reqwest",
@@ -1312,7 +1374,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1341,6 +1403,15 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1407,7 +1478,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1427,6 +1498,12 @@ name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "ppv-lite86"
@@ -1528,6 +1605,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -1844,7 +1931,7 @@ checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1897,6 +1984,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -1973,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2017,7 +2110,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2081,7 +2174,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2155,7 +2248,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2326,7 +2419,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -2360,7 +2453,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2599,6 +2692,26 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_ffi"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "object_store_ffi"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "hickory-dns"] }
 # object_store = { version = "0.10.1", features = ["azure", "aws"] }
 # Pinned to a specific commit while waiting for upstream
-object_store = { git = "https://github.com/andrebsguedes/arrow-rs.git", branch = "unsigned-payload-and-azure-list-offset", features = ["azure", "aws", "experimental-azure-list-offset", "experimental-arbitrary-list-prefix"] }
+object_store = { git = "https://github.com/andrebsguedes/arrow-rs.git", tag = "v0.10.2-beta1", features = ["azure", "aws", "experimental-azure-list-offset", "experimental-arbitrary-list-prefix"] }
 thiserror = "1"
 anyhow = { version = "1", features = ["backtrace"] }
 once_cell = "1.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ rand = "0.8.5"
 zeroize = "1.8.1"
 async-trait = "0.1.81"
 serde_path_to_error = "0.1.16"
+metrics = "0.23.0"
+metrics-util = "0.17.0"
+quanta = "0.12.3"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 openssl = { version = "0.10.66" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,17 @@ async-compression = { version = "0.4.6", default-features = false, features = ["
 flume = "0.11.0"
 pin-project = "1.1.5"
 uuid = { version = "1.10.0", features = ["v4"] }
-openssl = "0.10.66"
 base64 = "0.22.1"
 rand = "0.8.5"
 zeroize = "1.8.1"
 async-trait = "0.1.81"
 serde_path_to_error = "0.1.16"
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+openssl = { version = "0.10.66" }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+openssl = { version = "0.10.66", features = ["vendored"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", default-features = false, features = ["cargo_bench_support", "html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 
 # https://doc.rust-lang.org/cargo/reference/profiles.html
 [profile.release]
-debug = 1
+debug = true
 
 [features]
 default = ["julia"]
@@ -51,6 +51,13 @@ flate2 = { version = "1.0.28", features=["zlib-ng"], default-features = false}
 async-compression = { version = "0.4.6", default-features = false, features = ["tokio", "gzip", "zlib", "deflate", "zstd"] }
 flume = "0.11.0"
 pin-project = "1.1.5"
+uuid = { version = "1.10.0", features = ["v4"] }
+openssl = "0.10.66"
+base64 = "0.22.1"
+rand = "0.8.5"
+zeroize = "1.8.1"
+async-trait = "0.1.81"
+serde_path_to_error = "0.1.16"
 
 [dev-dependencies]
 criterion = { version = "0.4", default-features = false, features = ["cargo_bench_support", "html_reports"] }

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,11 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH"
+]
+
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH"
+]

--- a/src/crud_ops.rs
+++ b/src/crud_ops.rs
@@ -1,10 +1,11 @@
-use crate::{encryption::{encrypt, CrypterReader, CrypterWriter, Mode}, static_config, util::cstr_to_path, BoxedReader, BoxedUpload, CResult, Client, Context, NotifyGuard, RawConfig, RawResponse, Request, ResponseGuard, SQ};
+use crate::{encryption::{encrypt, CrypterReader, CrypterWriter, Mode}, error::RetryState, export_queued_op, static_config, util::cstr_to_path, with_retries, BoxedReader, BoxedUpload, CResult, Client, Context, NotifyGuard, RawConfig, RawResponse, Request, ResponseGuard, SQ};
 
+use bytes::Bytes;
 use object_store::{path::Path, ObjectStore};
 
 use anyhow::anyhow;
 use tokio_util::io::StreamReader;
-use std::ffi::{c_char, c_void};
+use std::{ffi::{c_char, c_void}, sync::Arc};
 use futures_util::{stream, StreamExt};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
@@ -74,230 +75,171 @@ async fn read_to_slice(reader: &mut BoxedReader, mut slice: &mut [u8]) -> anyhow
     Ok(received_bytes)
 }
 
-async fn multipart_get(slice: &mut [u8], path: &Path, client: &Client) -> anyhow::Result<usize> {
-    let result = client.store.get_opts(
-        &path,
-        object_store::GetOptions {
-            head: true,
-            ..Default::default()
+impl Client {
+    async fn get_impl(&self, path: &Path, slice: &mut [u8]) -> anyhow::Result<usize> {
+        let path = &self.full_path(path);
+
+        // Multipart Get
+        if slice.len() > static_config().multipart_get_threshold as usize {
+            return self.multipart_get_impl(path, slice).await
         }
-    ).await?;
 
-    let part_ranges = crate::util::size_to_ranges(result.meta.size);
-    let result_vec = client.store.get_ranges(&path, &part_ranges).await?;
-    let mut reader: BoxedReader = Box::new(StreamReader::new(stream::iter(result_vec).map(|b| Ok::<_, std::io::Error>(b))));
+        // Single part Get
+        let result = self.store.get(path).await?;
+        let attributes = result.attributes.clone();
 
-    if let Some(cryptmp) = client.crypto_material_provider.as_ref() {
-        let material = cryptmp.material_from_metadata(path.as_ref(), &result.attributes).await?;
-        let decrypter_reader = CrypterReader::new(reader, Mode::Decrypt, &material)?;
-        reader = Box::new(decrypter_reader);
+        let mut reader: Box<dyn AsyncRead + Send + Unpin> = Box::new(StreamReader::new(result.into_stream()));
+
+        if let Some(cryptmp) = self.crypto_material_provider.as_ref() {
+            let material = cryptmp.material_from_metadata(path.as_ref(), &attributes).await?;
+            let decrypter_reader = CrypterReader::new(reader, Mode::Decrypt, &material)?;
+            reader = Box::new(decrypter_reader);
+        }
+
+        Ok(read_to_slice(&mut reader, slice).await?)
     }
+    pub async fn get(&self, path: &Path, slice: &mut [u8]) -> anyhow::Result<usize> {
+        with_retries!(self, self.get_impl(path, slice).await)
+    }
+    async fn put_impl(&self, path: &Path, slice: Bytes) -> anyhow::Result<usize> {
+        let path = &self.full_path(path);
+        let len = slice.len();
+        if len < static_config().multipart_put_threshold as usize {
+            if let Some(cryptmp) = self.crypto_material_provider.as_ref() {
+                let (material, attrs) = cryptmp.material_for_write(path.as_ref(), Some(slice.len())).await?;
+                let ciphertext = if slice.is_empty() {
+                    // Do not write any padding if there was no data
+                    vec![]
+                } else {
+                    encrypt(&slice, &material)?
+                };
+                let _ = self.store.put_opts(
+                    path,
+                    ciphertext.into(),
+                    attrs.into()
+                ).await?;
+            } else {
+                let _ = self.store.put(path, slice.into()).await?;
+            }
+        } else {
+            return self.multipart_put_impl(path, &slice).await;
+        }
 
-    Ok(read_to_slice(&mut reader, slice).await?)
-}
+        Ok(len)
+    }
+    pub async fn put(&self, path: &Path, slice: Bytes) -> anyhow::Result<usize> {
+        with_retries!(self, self.put_impl(path, slice.clone()).await)
+    }
+    async fn delete_impl(&self, path: &Path) -> anyhow::Result<usize> {
+        let path = &self.full_path(path);
+        self.store.delete(path).await?;
+        Ok(0)
+    }
+    pub async fn delete(&self, path: &Path) -> anyhow::Result<usize> {
+        with_retries!(self, self.delete_impl(path).await)
+    }
+    async fn multipart_get_impl(&self, path: &Path, slice: &mut [u8]) -> anyhow::Result<usize> {
+        let result = self.store.get_opts(
+            &path,
+            object_store::GetOptions {
+                head: true,
+                ..Default::default()
+            }
+        ).await?;
 
-async fn multipart_put(slice: &[u8], path: &Path, client: Client) -> anyhow::Result<()> {
-    let mut writer: BoxedUpload = if let Some(cryptmp) = client.crypto_material_provider.as_ref() {
-        let (material, attrs) = cryptmp.material_for_write(path.as_ref(), Some(slice.len())).await?;
-        let writer = object_store::buffered::BufWriter::with_capacity(
-            client.store,
-            path.clone(),
-            10 * 1024 * 1024
-        )
-            .with_attributes(attrs)
-            .with_max_concurrency(64);
-        let encrypter_writer = CrypterWriter::new(writer, Mode::Encrypt, &material)?;
-        Box::new(encrypter_writer)
-    } else {
-        Box::new(
-            object_store::buffered::BufWriter::with_capacity(
-                client.store,
+        let part_ranges = crate::util::size_to_ranges(result.meta.size);
+        let result_vec = self.store.get_ranges(&path, &part_ranges).await?;
+        let mut reader: BoxedReader = Box::new(StreamReader::new(stream::iter(result_vec).map(|b| Ok::<_, std::io::Error>(b))));
+
+        if let Some(cryptmp) = self.crypto_material_provider.as_ref() {
+            let material = cryptmp.material_from_metadata(path.as_ref(), &result.attributes).await?;
+            let decrypter_reader = CrypterReader::new(reader, Mode::Decrypt, &material)?;
+            reader = Box::new(decrypter_reader);
+        }
+
+        Ok(read_to_slice(&mut reader, slice).await?)
+    }
+    pub async fn multipart_get(&self, path: &Path, slice: &mut [u8]) -> anyhow::Result<usize> {
+        with_retries!(self, self.multipart_get_impl(path, slice).await)
+    }
+    async fn multipart_put_impl(&self, path: &Path, slice: &[u8]) -> anyhow::Result<usize> {
+        let mut writer: BoxedUpload = if let Some(cryptmp) = self.crypto_material_provider.as_ref() {
+            let (material, attrs) = cryptmp.material_for_write(path.as_ref(), Some(slice.len())).await?;
+            let writer = object_store::buffered::BufWriter::with_capacity(
+                Arc::clone(&self.store),
                 path.clone(),
                 10 * 1024 * 1024
             )
-            .with_max_concurrency(64)
-        )
-    };
-
-    match writer.write_all(slice).await {
-        Ok(_) => {
-            match writer.flush().await {
-                Ok(_) => {
-                    writer.shutdown().await?;
-                    return Ok(());
-                }
-                Err(e) => {
-                    writer.abort().await?;
-                    return Err(e.into());
-                }
-            }
-        }
-        Err(e) => {
-            writer.abort().await?;
-            return Err(e.into());
-        }
-    };
-}
-
-pub(crate) async fn handle_get(client: Client, slice: &mut [u8], path: &Path) -> anyhow::Result<usize> {
-    let path = &client.full_path(path);
-
-    // Multipart Get
-    if slice.len() > static_config().multipart_get_threshold as usize {
-        let accum = multipart_get(slice, path, &client).await?;
-        return Ok(accum);
-    }
-
-    // Single part Get
-    let result = client.store.get(path).await?;
-    let attributes = result.attributes.clone();
-
-    let mut reader: Box<dyn AsyncRead + Send + Unpin> = Box::new(StreamReader::new(result.into_stream()));
-
-    if let Some(cryptmp) = client.crypto_material_provider.as_ref() {
-        let material = cryptmp.material_from_metadata(path.as_ref(), &attributes).await?;
-        let decrypter_reader = CrypterReader::new(reader, Mode::Decrypt, &material)?;
-        reader = Box::new(decrypter_reader);
-    }
-
-    Ok(read_to_slice(&mut reader, slice).await?)
-}
-
-pub(crate) async fn handle_put(client: Client, slice: &'static [u8], path: &Path) -> anyhow::Result<usize> {
-    let path = &client.full_path(path);
-    let len = slice.len();
-    if len < static_config().multipart_put_threshold as usize {
-        if let Some(cryptmp) = client.crypto_material_provider.as_ref() {
-            let (material, attrs) = cryptmp.material_for_write(path.as_ref(), Some(slice.len())).await?;
-            let ciphertext = if slice.is_empty() {
-                // Do not write any padding if there was no data
-                vec![]
-            } else {
-                encrypt(&slice, &material)?
-            };
-            let _ = client.store.put_opts(
-                path,
-                ciphertext.into(),
-                attrs.into()
-            ).await?;
+                .with_attributes(attrs)
+                .with_max_concurrency(64);
+            let encrypter_writer = CrypterWriter::new(writer, Mode::Encrypt, &material)?;
+            Box::new(encrypter_writer)
         } else {
-            let _ = client.store.put(path, slice.into()).await?;
-        }
-    } else {
-        let _ = multipart_put(slice, path, client).await?;
-    }
+            Box::new(
+                object_store::buffered::BufWriter::with_capacity(
+                    Arc::clone(&self.store),
+                    path.clone(),
+                    10 * 1024 * 1024
+                )
+                .with_max_concurrency(64)
+            )
+        };
 
-    Ok(len)
-}
-
-pub(crate) async fn handle_delete(client: Client, path: &Path) -> anyhow::Result<usize> {
-    let path = &client.full_path(path);
-    client.store.delete(path).await?;
-
-    Ok(0)
-}
-
-#[no_mangle]
-pub extern "C" fn get(
-    path: *const c_char,
-    buffer: *mut u8,
-    size: usize,
-    config: *const RawConfig,
-    response: *mut Response,
-    handle: *const c_void
-) -> CResult {
-    let response = unsafe { ResponseGuard::new(response, handle) };
-    let path = unsafe { std::ffi::CStr::from_ptr(path) };
-    let path = unsafe{ cstr_to_path(path) };
-    let slice = unsafe { std::slice::from_raw_parts_mut(buffer, size) };
-    let config = unsafe { & (*config) };
-    match SQ.get() {
-        Some(sq) => {
-            match sq.try_send(Request::Get(path, slice, config, response)) {
-                Ok(_) => CResult::Ok,
-                Err(flume::TrySendError::Full(Request::Get(_, _, _, response))) => {
-                    response.into_error("object_store_ffi internal channel full, backoff");
-                    CResult::Backoff
+        match writer.write_all(slice).await {
+            Ok(_) => {
+                match writer.flush().await {
+                    Ok(_) => {
+                        writer.shutdown().await?;
+                        return Ok(slice.len());
+                    }
+                    Err(e) => {
+                        writer.abort().await?;
+                        return Err(e.into());
+                    }
                 }
-                Err(flume::TrySendError::Disconnected(Request::Get(_, _, _, response))) => {
-                    response.into_error("object_store_ffi internal channel closed (may be missing initialization)");
-                    CResult::Error
-                }
-                _ => unreachable!("the response type must match")
             }
-        }
-        None => {
-            response.into_error("object_store_ffi internal channel closed (may be missing initialization)");
-            return CResult::Error;
-        }
+            Err(e) => {
+                writer.abort().await?;
+                return Err(e.into());
+            }
+        };
+    }
+    pub async fn multipart_put(&self, path: &Path, slice: &[u8]) -> anyhow::Result<usize> {
+        with_retries!(self, self.multipart_put_impl(path, slice).await)
     }
 }
 
-#[no_mangle]
-pub extern "C" fn put(
-    path: *const c_char,
-    buffer: *const u8,
-    size: usize,
-    config: *const RawConfig,
-    response: *mut Response,
-    handle: *const c_void
-) -> CResult {
-    let response = unsafe { ResponseGuard::new(response, handle) };
-    let path = unsafe { std::ffi::CStr::from_ptr(path) };
-    let path = unsafe{ cstr_to_path(path) };
-    let slice = unsafe { std::slice::from_raw_parts(buffer, size) };
-    let config = unsafe { & (*config) };
-    match SQ.get() {
-        Some(sq) => {
-            match sq.try_send(Request::Put(path, slice, config, response)) {
-                Ok(_) => CResult::Ok,
-                Err(flume::TrySendError::Full(Request::Put(_, _, _, response))) => {
-                    response.into_error("object_store_ffi internal channel full, backoff");
-                    CResult::Backoff
-                }
-                Err(flume::TrySendError::Disconnected(Request::Put(_, _, _, response))) => {
-                    response.into_error("object_store_ffi internal channel closed (may be missing initialization)");
-                    CResult::Error
-                }
-                _ => unreachable!("the response type must match")
-            }
-        }
-        None => {
-            response.into_error("object_store_ffi internal channel closed (may be missing initialization)");
-            return CResult::Error;
-        }
-    }
-}
+export_queued_op!(
+    get,
+    Response,
+    |config, response| {
+        let path = unsafe { std::ffi::CStr::from_ptr(path) };
+        let path = unsafe{ cstr_to_path(path) };
+        let slice = unsafe { std::slice::from_raw_parts_mut(buffer, size) };
+        Ok(Request::Get(path, slice, config, response))
+    },
+    path: *const c_char, buffer: *mut u8, size: usize
+);
 
-#[no_mangle]
-pub extern "C" fn delete(
-    path: *const c_char,
-    config: *const RawConfig,
-    response: *mut Response,
-    handle: *const c_void
-) -> CResult {
-    let response = unsafe { ResponseGuard::new(response, handle) };
-    let path = unsafe { std::ffi::CStr::from_ptr(path) };
-    let path = unsafe{ cstr_to_path(path) };
-    let config = unsafe { & (*config) };
-    match SQ.get() {
-        Some(sq) => {
-            match sq.try_send(Request::Delete(path, config, response)) {
-                Ok(_) => CResult::Ok,
-                Err(flume::TrySendError::Full(Request::Delete(_, _, response))) => {
-                    response.into_error("object_store_ffi internal channel full, backoff");
-                    CResult::Backoff
-                }
-                Err(flume::TrySendError::Disconnected(Request::Delete(_, _, response))) => {
-                    response.into_error("object_store_ffi internal channel closed (may be missing initialization)");
-                    CResult::Error
-                }
-                _ => unreachable!("the response type must match")
-            }
-        }
-        None => {
-            response.into_error("object_store_ffi internal channel closed (may be missing initialization)");
-            return CResult::Error;
-        }
-    }
-}
+export_queued_op!(
+    put,
+    Response,
+    |config, response| {
+        let path = unsafe { std::ffi::CStr::from_ptr(path) };
+        let path = unsafe{ cstr_to_path(path) };
+        let slice = unsafe { std::slice::from_raw_parts(buffer, size) };
+        Ok(Request::Put(path, slice, config, response))
+    },
+    path: *const c_char, buffer: *const u8, size: usize
+);
+
+export_queued_op!(
+    delete,
+    Response,
+    |config, response| {
+        let path = unsafe { std::ffi::CStr::from_ptr(path) };
+        let path = unsafe{ cstr_to_path(path) };
+        Ok(Request::Delete(path, config, response))
+    },
+    path: *const c_char
+);

--- a/src/crud_ops.rs
+++ b/src/crud_ops.rs
@@ -1,9 +1,9 @@
-use crate::{encryption::{encrypt, CrypterReader, CrypterWriter, Mode}, error::RetryState, export_queued_op, static_config, util::cstr_to_path, with_retries, BoxedReader, BoxedUpload, CResult, Client, Context, NotifyGuard, RawConfig, RawResponse, Request, ResponseGuard, SQ};
+use crate::{duration_on_drop, encryption::{encrypt, CrypterReader, CrypterWriter, Mode}, error::Kind as ErrorKind, export_queued_op, metrics, util::cstr_to_path, with_retries, BoxedReader, BoxedUpload, CResult, Client, Context, NotifyGuard, RawConfig, RawResponse, Request, ResponseGuard, SQ};
 
 use bytes::Bytes;
+use ::metrics::counter;
 use object_store::{path::Path, ObjectStore};
 
-use anyhow::anyhow;
 use tokio_util::io::StreamReader;
 use std::{ffi::{c_char, c_void}, sync::Arc};
 use futures_util::{stream, StreamExt};
@@ -44,7 +44,7 @@ impl RawResponse for Response {
     }
 }
 
-async fn read_to_slice(reader: &mut BoxedReader, mut slice: &mut [u8]) -> anyhow::Result<usize> {
+async fn read_to_slice(reader: &mut BoxedReader, mut slice: &mut [u8]) -> crate::Result<usize> {
     let mut received_bytes = 0;
     loop {
         match reader.read_buf(&mut slice).await {
@@ -56,7 +56,7 @@ async fn read_to_slice(reader: &mut BoxedReader, mut slice: &mut [u8]) -> anyhow
                         // slice was the exact size, done
                         break;
                     } else {
-                        return Err(anyhow!("Supplied buffer was too small"));
+                        return Err(ErrorKind::BufferTooSmall.into());
                     }
                 } else {
                     // done
@@ -65,9 +65,9 @@ async fn read_to_slice(reader: &mut BoxedReader, mut slice: &mut [u8]) -> anyhow
             }
             Ok(n) => received_bytes += n,
             Err(e) => {
-                let err = anyhow::Error::new(e);
-                tracing::warn!("Error while reading body: {:#}", err);
-                return Err(err);
+                let err = ErrorKind::BodyIo(e);
+                tracing::warn!("Error while reading body: {}", err);
+                return Err(err.into());
             }
         }
     }
@@ -76,11 +76,13 @@ async fn read_to_slice(reader: &mut BoxedReader, mut slice: &mut [u8]) -> anyhow
 }
 
 impl Client {
-    async fn get_impl(&self, path: &Path, slice: &mut [u8]) -> anyhow::Result<usize> {
+    async fn get_impl(&self, path: &Path, slice: &mut [u8]) -> crate::Result<usize> {
+        let guard = duration_on_drop!(metrics::get_attempt_duration);
         let path = &self.full_path(path);
 
         // Multipart Get
-        if slice.len() > static_config().multipart_get_threshold as usize {
+        if slice.len() > self.config.multipart_get_threshold {
+            guard.discard();
             return self.multipart_get_impl(path, slice).await
         }
 
@@ -92,26 +94,30 @@ impl Client {
 
         if let Some(cryptmp) = self.crypto_material_provider.as_ref() {
             let material = cryptmp.material_from_metadata(path.as_ref(), &attributes).await?;
-            let decrypter_reader = CrypterReader::new(reader, Mode::Decrypt, &material)?;
+            let decrypter_reader = CrypterReader::new(reader, Mode::Decrypt, &material)
+                .map_err(ErrorKind::ContentDecrypt)?;
             reader = Box::new(decrypter_reader);
         }
 
         Ok(read_to_slice(&mut reader, slice).await?)
     }
-    pub async fn get(&self, path: &Path, slice: &mut [u8]) -> anyhow::Result<usize> {
+    pub async fn get(&self, path: &Path, slice: &mut [u8]) -> crate::Result<usize> {
+        counter!(metrics::total_get_ops).increment(1);
         with_retries!(self, self.get_impl(path, slice).await)
     }
-    async fn put_impl(&self, path: &Path, slice: Bytes) -> anyhow::Result<usize> {
+    async fn put_impl(&self, path: &Path, slice: Bytes) -> crate::Result<usize> {
+        let guard = duration_on_drop!(metrics::put_attempt_duration);
         let path = &self.full_path(path);
         let len = slice.len();
-        if len < static_config().multipart_put_threshold as usize {
+        if len < self.config.multipart_put_threshold {
             if let Some(cryptmp) = self.crypto_material_provider.as_ref() {
                 let (material, attrs) = cryptmp.material_for_write(path.as_ref(), Some(slice.len())).await?;
                 let ciphertext = if slice.is_empty() {
                     // Do not write any padding if there was no data
                     vec![]
                 } else {
-                    encrypt(&slice, &material)?
+                    encrypt(&slice, &material)
+                        .map_err(ErrorKind::ContentEncrypt)?
                 };
                 let _ = self.store.put_opts(
                     path,
@@ -122,23 +128,28 @@ impl Client {
                 let _ = self.store.put(path, slice.into()).await?;
             }
         } else {
+            guard.discard();
             return self.multipart_put_impl(path, &slice).await;
         }
 
         Ok(len)
     }
-    pub async fn put(&self, path: &Path, slice: Bytes) -> anyhow::Result<usize> {
+    pub async fn put(&self, path: &Path, slice: Bytes) -> crate::Result<usize> {
+        counter!(metrics::total_put_ops).increment(1);
         with_retries!(self, self.put_impl(path, slice.clone()).await)
     }
-    async fn delete_impl(&self, path: &Path) -> anyhow::Result<usize> {
+    async fn delete_impl(&self, path: &Path) -> crate::Result<usize> {
+        let _guard = duration_on_drop!(metrics::delete_attempt_duration);
         let path = &self.full_path(path);
         self.store.delete(path).await?;
         Ok(0)
     }
-    pub async fn delete(&self, path: &Path) -> anyhow::Result<usize> {
+    pub async fn delete(&self, path: &Path) -> crate::Result<usize> {
+        counter!(metrics::total_delete_ops).increment(1);
         with_retries!(self, self.delete_impl(path).await)
     }
-    async fn multipart_get_impl(&self, path: &Path, slice: &mut [u8]) -> anyhow::Result<usize> {
+    async fn multipart_get_impl(&self, path: &Path, slice: &mut [u8]) -> crate::Result<usize> {
+        let _guard = duration_on_drop!(metrics::multipart_get_attempt_duration);
         let result = self.store.get_opts(
             &path,
             object_store::GetOptions {
@@ -147,41 +158,44 @@ impl Client {
             }
         ).await?;
 
-        let part_ranges = crate::util::size_to_ranges(result.meta.size);
+        let part_ranges = crate::util::size_to_ranges(result.meta.size, self.config.multipart_get_part_size);
         let result_vec = self.store.get_ranges(&path, &part_ranges).await?;
         let mut reader: BoxedReader = Box::new(StreamReader::new(stream::iter(result_vec).map(|b| Ok::<_, std::io::Error>(b))));
 
         if let Some(cryptmp) = self.crypto_material_provider.as_ref() {
             let material = cryptmp.material_from_metadata(path.as_ref(), &result.attributes).await?;
-            let decrypter_reader = CrypterReader::new(reader, Mode::Decrypt, &material)?;
+            let decrypter_reader = CrypterReader::new(reader, Mode::Decrypt, &material)
+                .map_err(ErrorKind::ContentDecrypt)?;
             reader = Box::new(decrypter_reader);
         }
 
         Ok(read_to_slice(&mut reader, slice).await?)
     }
-    pub async fn multipart_get(&self, path: &Path, slice: &mut [u8]) -> anyhow::Result<usize> {
+    pub async fn multipart_get(&self, path: &Path, slice: &mut [u8]) -> crate::Result<usize> {
         with_retries!(self, self.multipart_get_impl(path, slice).await)
     }
-    async fn multipart_put_impl(&self, path: &Path, slice: &[u8]) -> anyhow::Result<usize> {
+    async fn multipart_put_impl(&self, path: &Path, slice: &[u8]) -> crate::Result<usize> {
+        let _guard = duration_on_drop!(metrics::multipart_put_attempt_duration);
         let mut writer: BoxedUpload = if let Some(cryptmp) = self.crypto_material_provider.as_ref() {
             let (material, attrs) = cryptmp.material_for_write(path.as_ref(), Some(slice.len())).await?;
             let writer = object_store::buffered::BufWriter::with_capacity(
                 Arc::clone(&self.store),
                 path.clone(),
-                10 * 1024 * 1024
+                self.config.multipart_put_part_size
             )
                 .with_attributes(attrs)
-                .with_max_concurrency(64);
-            let encrypter_writer = CrypterWriter::new(writer, Mode::Encrypt, &material)?;
+                .with_max_concurrency(self.config.multipart_put_concurrency);
+            let encrypter_writer = CrypterWriter::new(writer, Mode::Encrypt, &material)
+                .map_err(ErrorKind::ContentEncrypt)?;
             Box::new(encrypter_writer)
         } else {
             Box::new(
                 object_store::buffered::BufWriter::with_capacity(
                     Arc::clone(&self.store),
                     path.clone(),
-                    10 * 1024 * 1024
+                    self.config.multipart_put_part_size
                 )
-                .with_max_concurrency(64)
+                .with_max_concurrency(self.config.multipart_put_concurrency)
             )
         };
 
@@ -189,22 +203,23 @@ impl Client {
             Ok(_) => {
                 match writer.flush().await {
                     Ok(_) => {
-                        writer.shutdown().await?;
+                        writer.shutdown().await
+                            .map_err(ErrorKind::BodyIo)?;
                         return Ok(slice.len());
                     }
                     Err(e) => {
                         writer.abort().await?;
-                        return Err(e.into());
+                        return Err(ErrorKind::BodyIo(e).into());
                     }
                 }
             }
             Err(e) => {
                 writer.abort().await?;
-                return Err(e.into());
+                return Err(ErrorKind::BodyIo(e).into());
             }
         };
     }
-    pub async fn multipart_put(&self, path: &Path, slice: &[u8]) -> anyhow::Result<usize> {
+    pub async fn multipart_put(&self, path: &Path, slice: &[u8]) -> crate::Result<usize> {
         with_retries!(self, self.multipart_put_impl(path, slice).await)
     }
 }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,0 +1,999 @@
+use openssl::symm::{self, encrypt_aead, decrypt_aead, Cipher, Crypter};
+use pin_project::pin_project;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use zeroize::Zeroize;
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use bytes::Bytes;
+use futures_util::ready;
+use std::{fmt::{self, Debug}, ops::{Deref, DerefMut}};
+
+use base64::prelude::*;
+use rand::{RngCore, rngs::OsRng};
+use object_store::Attributes;
+
+use crate::util::AsyncUpload;
+
+const AES_GCM_TAG_BYTES: usize = 16;
+
+#[async_trait::async_trait]
+pub(crate) trait CryptoMaterialProvider:
+    Send
+    + Sync
+    + Debug
+    + 'static {
+    async fn material_for_write(&self, path: &str, data_len: Option<usize>) -> anyhow::Result<(ContentCryptoMaterial, Attributes)>;
+    async fn material_from_metadata(&self, path: &str, attr: &Attributes) -> anyhow::Result<ContentCryptoMaterial>;
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum CryptoScheme {
+    Aes256Gcm,
+    Aes128Cbc
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum Mode {
+    Encrypt,
+    Decrypt
+}
+
+impl From<Mode> for openssl::symm::Mode {
+    fn from(v: Mode) -> openssl::symm::Mode {
+        match v {
+            Mode::Encrypt => openssl::symm::Mode::Encrypt,
+            Mode::Decrypt => openssl::symm::Mode::Decrypt
+        }
+    }
+}
+
+impl CryptoScheme {
+    pub(crate) fn key_len(&self) -> usize {
+        self.cipher().key_len()
+    }
+    pub(crate) fn iv_len(&self) -> usize {
+        self.cipher().iv_len().expect("needs iv")
+    }
+    pub(crate) fn tag_len(&self) -> usize {
+        match self {
+            CryptoScheme::Aes256Gcm => AES_GCM_TAG_BYTES,
+            CryptoScheme::Aes128Cbc => 0
+        }
+    }
+    pub(crate) fn cipher(&self) -> Cipher {
+        match self {
+            CryptoScheme::Aes256Gcm => Cipher::aes_256_gcm(),
+            CryptoScheme::Aes128Cbc => Cipher::aes_128_cbc(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Iv {
+    bytes: Vec<u8>
+}
+
+impl Deref for Iv {
+    type Target = [u8];
+
+    #[inline(always)]
+    fn deref(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+}
+
+impl DerefMut for Iv {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut [u8] {
+        self.bytes.as_mut_slice()
+    }
+}
+
+impl Iv {
+    pub(crate) fn from_base64(iv: impl AsRef<str>) -> Result<Iv, base64::DecodeError> {
+        Ok(Iv { bytes: BASE64_STANDARD.decode(iv.as_ref())? })
+    }
+    pub(crate) fn generate(len: usize) -> Iv {
+        let mut bytes = vec![0; len];
+        OsRng.fill_bytes(&mut bytes);
+        Iv { bytes }
+    }
+    #[allow(unused)]
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+    pub(crate) fn as_base64(&self) -> String {
+        BASE64_STANDARD.encode(&self.bytes)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Key {
+    bytes: Vec<u8>
+}
+
+impl Deref for Key {
+    type Target = [u8];
+
+    #[inline(always)]
+    fn deref(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+}
+
+impl DerefMut for Key {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut [u8] {
+        self.bytes.as_mut_slice()
+    }
+}
+
+impl Key {
+    pub(crate) fn from_base64(key: impl AsRef<str>) -> Result<Key, base64::DecodeError> {
+        Ok(Key { bytes: BASE64_STANDARD.decode(key.as_ref())? })
+    }
+    pub(crate) fn generate(len: usize) -> Key {
+        let mut bytes = vec![0; len];
+        OsRng.fill_bytes(&mut bytes);
+        Key { bytes }
+    }
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+    pub(crate) fn encrypt_aes_128_ecb(self, encryption_key: &Key) -> std::io::Result<EncryptedKey> {
+        let cipher = Cipher::aes_128_ecb();
+        if encryption_key.len() != cipher.key_len() {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid key size"));
+        }
+
+        let encrypted_bytes = symm::encrypt(cipher, &encryption_key, None, &self)?;
+
+        Ok(EncryptedKey { bytes: encrypted_bytes })
+    }
+    #[allow(unused)]
+    pub(crate) fn as_base64(&self) -> String {
+        BASE64_STANDARD.encode(&self.bytes)
+    }
+}
+
+impl Drop for Key {
+    fn drop(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+// Always encrypted with aes_128_ecb for now
+#[derive(Clone)]
+pub(crate) struct EncryptedKey {
+    bytes: Vec<u8>,
+}
+
+impl EncryptedKey {
+    pub(crate) fn from_base64(key: impl AsRef<str>) -> Result<EncryptedKey, base64::DecodeError> {
+        Ok(EncryptedKey { bytes: BASE64_STANDARD.decode(key.as_ref())? })
+    }
+    pub(crate) fn decrypt_aes_128_ecb(self, decryption_key: &Key) -> std::io::Result<Key> {
+        let cipher = Cipher::aes_128_ecb();
+        if decryption_key.len() != cipher.key_len() {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid key size"));
+        }
+        let bytes = symm::decrypt(cipher, &decryption_key, None, &self.bytes)?;
+
+        Ok(Key { bytes })
+    }
+    pub(crate) fn as_base64(&self) -> String {
+        BASE64_STANDARD.encode(&self.bytes)
+    }
+}
+
+impl Drop for EncryptedKey {
+    fn drop(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+pub(crate) struct ContentCryptoMaterial {
+    pub scheme: CryptoScheme,
+    pub cek: Key,
+    pub iv: Iv,
+    pub aad: Option<Bytes>
+}
+
+impl ContentCryptoMaterial {
+    pub fn generate(scheme: CryptoScheme) -> ContentCryptoMaterial {
+        let cek = Key::generate(scheme.key_len());
+        let iv = Iv::generate(scheme.iv_len());
+        ContentCryptoMaterial { scheme, cek, iv, aad: None }
+    }
+
+    pub fn with_aad(self, aad: impl Into<Bytes>) -> ContentCryptoMaterial {
+        ContentCryptoMaterial { aad: Some(aad.into()), ..self }
+    }
+}
+
+pub(crate) fn encrypt(
+    data: &[u8],
+    material: &ContentCryptoMaterial
+) -> std::io::Result<Vec<u8>> {
+    match material.scheme {
+        CryptoScheme::Aes128Cbc => {
+            let ContentCryptoMaterial { scheme, cek, iv, .. } = material;
+            Ok(symm::encrypt(scheme.cipher(), &cek, Some(&iv), data)?)
+
+        },
+        CryptoScheme::Aes256Gcm => {
+            let ContentCryptoMaterial { scheme, cek, iv, aad, .. } = material;
+            let aad_ref = aad.as_deref().unwrap_or_default();
+            let mut tag = vec![0; scheme.tag_len()];
+            let mut ciphertext = encrypt_aead(scheme.cipher(), &cek, Some(&iv), aad_ref, data, &mut tag)?;
+            // Postfix tag
+            ciphertext.extend_from_slice(&tag);
+            Ok(ciphertext)
+        }
+    }
+}
+
+#[allow(unused)]
+pub(crate) fn decrypt(
+    ciphertext: &[u8],
+    material: &ContentCryptoMaterial
+) -> std::io::Result<Vec<u8>> {
+    match material.scheme {
+        CryptoScheme::Aes128Cbc => {
+            let ContentCryptoMaterial { scheme, cek, iv, .. } = material;
+            Ok(symm::decrypt(scheme.cipher(), &cek, Some(&iv), ciphertext)?)
+
+        },
+        CryptoScheme::Aes256Gcm => {
+            let ContentCryptoMaterial { scheme, cek, iv, aad, .. } = material;
+            let aad_ref = aad.as_deref().unwrap_or_default();
+            // Postfix tag
+            let tag_offset = ciphertext.len() - AES_GCM_TAG_BYTES;
+            let data = decrypt_aead(scheme.cipher(), &cek, Some(&iv), aad_ref, &ciphertext[..tag_offset], &ciphertext[tag_offset..])?;
+            Ok(data)
+        }
+    }
+}
+
+struct Buffer {
+    buf: Vec<u8>,
+    pos: usize,
+    filled: usize
+}
+
+impl Buffer {
+    fn with_capacity(cap: usize) -> Buffer {
+        Buffer {
+            buf: vec![0; cap],
+            pos: 0,
+            filled: 0
+        }
+    }
+
+    #[inline]
+    #[track_caller]
+    fn consume(&mut self, n: usize) {
+        assert!(self.pos + n <= self.filled);
+        self.pos += n;
+    }
+
+    #[inline]
+    #[track_caller]
+    fn advance(&mut self, n: usize) {
+        assert!(self.filled + n <= self.capacity());
+        self.filled += n;
+    }
+
+    /// Returns the total capacity of the buffer.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Returns a shared reference to the filled portion of the buffer.
+    #[inline]
+    pub fn filled(&self) -> &[u8] {
+        &self.buf[self.pos..self.filled]
+    }
+
+    /// Returns a mutable reference to the filled portion of the buffer.
+    #[inline]
+    #[allow(unused)]
+    pub fn filled_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.pos..self.filled]
+    }
+
+    #[inline]
+    pub fn unfilled(&self) -> &[u8] {
+        &self.buf[self.filled..]
+    }
+
+    #[inline]
+    pub fn unfilled_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.filled..]
+    }
+
+    /// Returns the number of bytes at the end of the slice that have not yet been filled.
+    #[inline]
+    pub fn remaining(&self) -> usize {
+        self.capacity() - self.filled
+    }
+
+    /// Returns the number of bytes at the end of the slice that have not yet been filled.
+    #[inline]
+    #[allow(unused)]
+    pub fn available(&self) -> usize {
+        self.filled - self.pos
+    }
+
+    /// Clears the buffer, resetting the filled region to empty.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.pos = 0;
+        self.filled = 0;
+    }
+
+    /// Compacts the filled portion to the start of the buffer.
+    #[inline]
+    pub fn compact(&mut self) {
+        let len = self.filled - self.pos;
+        self.buf.copy_within(self.pos..self.filled, 0);
+        self.pos = 0;
+        self.filled = len;
+    }
+
+    /// Appends data to the buffer, advancing the filled position.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.remaining()` is less than `buf.len()`.
+    #[inline]
+    #[track_caller]
+    pub fn put_slice(&mut self, buf: &[u8]) {
+        assert!(
+            self.remaining() >= buf.len(),
+            "buf.len() must fit in remaining(); buf.len() = {}, remaining() = {}",
+            buf.len(),
+            self.remaining()
+        );
+
+        let amt = buf.len();
+        // Cannot overflow, asserted above
+        let end = self.filled + amt;
+
+        // Safety: the length is asserted above
+        unsafe {
+            self.buf[self.filled..end]
+                .as_mut_ptr()
+                .cast::<u8>()
+                .copy_from_nonoverlapping(buf.as_ptr(), amt);
+        }
+
+        self.filled = end;
+    }
+}
+
+#[derive(Debug)]
+enum State {
+    Initial,
+    Filling,
+    Crypting,
+    Flushing,
+    Finalizing,
+    Done,
+}
+
+#[pin_project]
+pub struct CrypterReader<R> {
+    #[pin]
+    reader: R,
+    crypter: Crypter,
+    mode: Mode,
+    tag_len: usize,
+    block_size: usize,
+    inbuf: Buffer,
+    outbuf: Buffer,
+    state: State,
+    last_flush: bool
+}
+
+impl<T> fmt::Debug for CrypterReader<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CrypterReader")
+            .field("block_size", &self.block_size)
+            .field("mode", &self.mode)
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+impl<R: AsyncRead> CrypterReader<R> {
+    pub fn new(reader: R, mode: Mode, material: &ContentCryptoMaterial) -> std::io::Result<Self> {
+        CrypterReader::with_capacity(reader, mode, material, 64 * 1024)
+    }
+    pub fn with_capacity(reader: R, mode: Mode, material: &ContentCryptoMaterial, capacity: usize) -> std::io::Result<Self> {
+        let ContentCryptoMaterial { scheme, cek, iv, aad, .. } = material;
+        let cipher = scheme.cipher();
+        let block_size = cipher.block_size();
+        let mut crypter = Crypter::new(cipher, mode.into(), cek, Some(iv))?;
+        let tag_len = scheme.tag_len();
+        if let Some(aad) = aad {
+            crypter.aad_update(aad)?;
+        }
+        Ok(Self {
+            reader,
+            crypter,
+            mode,
+            tag_len,
+            block_size,
+            inbuf: Buffer::with_capacity(capacity),
+            outbuf: Buffer::with_capacity(block_size + block_size + tag_len),
+            state: State::Initial,
+            last_flush: false
+        })
+    }
+
+    pub fn get_ref(&self) -> &R {
+        &self.reader
+    }
+
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut R> {
+        self.project().reader
+    }
+
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
+}
+
+impl<R: AsyncRead> AsyncRead for CrypterReader<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(())); // Maybe should error instead
+        }
+
+        let mut this = self.project();
+        let block_size = *this.block_size;
+
+        // Size of the tag to extract from end of ciphertext
+        let extract_tag_len = match this.mode {
+            Mode::Encrypt => 0,
+            Mode::Decrypt => *this.tag_len
+        };
+        // Size of the tag to append to end of ciphertext
+        let append_tag_len = match this.mode {
+            Mode::Encrypt => *this.tag_len,
+            Mode::Decrypt => 0
+        };
+
+        loop {
+            *this.state = match this.state {
+                State::Initial => {
+                    let mut buf = ReadBuf::new(this.inbuf.unfilled_mut());
+                    ready!(this.reader.as_mut().poll_read(cx, &mut buf))?;
+                    let amt = buf.filled().len();
+                    this.inbuf.advance(amt);
+                    if amt == 0 {
+                        // never crypted anything, go to State::Done without flushing
+                        State::Done
+                    } else {
+                        // got some bytes, fill buffer
+                        State::Filling
+                    }
+                }
+                State::Filling => {
+                    if this.inbuf.filled().len() <= extract_tag_len {
+                        // we have up to tag_len bytes filled, bring them to the start of the
+                        // buffer
+                        this.inbuf.compact();
+                    }
+                    if this.inbuf.unfilled().len() > 0 {
+                        let mut buf = ReadBuf::new(this.inbuf.unfilled_mut());
+                        ready!(this.reader.as_mut().poll_read(cx, &mut buf))?;
+                        let amt = buf.filled().len();
+                        this.inbuf.advance(amt);
+                        if amt == 0 {
+                            // reached reader eof
+                            if this.inbuf.filled().len() <= extract_tag_len {
+                                // may have enough bytes for a tag
+                                State::Finalizing
+                            } else {
+                                // we still have some extra bytes to crypt
+                                State::Crypting
+                            }
+                        } else {
+                            State::Filling
+                        }
+                    } else {
+                        // we are full, go crypt
+                        State::Crypting
+                    }
+                }
+                State::Crypting => {
+                    if this.inbuf.filled().len() > extract_tag_len {
+                        if buf.remaining() > block_size {
+                            // readbuf is big enough, crypt directly into it
+                            let to_crypt = (this.inbuf.filled().len() - extract_tag_len).min(buf.remaining() - block_size);
+                            let amount = this.crypter.update(&this.inbuf.filled()[..to_crypt], buf.initialize_unfilled())?;
+                            buf.advance(amount);
+                            this.inbuf.consume(to_crypt);
+                            State::Crypting
+                        } else {
+                            // readbuf is too small, crypt to outbuf then flush
+                            let to_crypt = (this.inbuf.filled().len() - extract_tag_len).min(this.outbuf.unfilled().len() - block_size);
+                            let amount = this.crypter.update(&this.inbuf.filled()[..to_crypt], this.outbuf.unfilled_mut())?;
+                            this.outbuf.advance(amount);
+                            this.inbuf.consume(to_crypt);
+                            State::Flushing
+                        }
+                    } else {
+                        // not enough to continue crypting, go fill
+                        State::Filling
+                    }
+                }
+                State::Flushing => {
+                    if this.outbuf.filled().len() > 0 {
+                        let to_copy = this.outbuf.filled().len().min(buf.remaining());
+                        buf.put_slice(&this.outbuf.filled()[..to_copy]);
+                        this.outbuf.consume(to_copy);
+                        State::Flushing
+                    } else {
+                        if *this.last_flush {
+                            // outbuf is empty and was last flush, done
+                            this.outbuf.clear();
+                            State::Done
+                        } else {
+                            // outbuf is empty, reset it and go crypt
+                            this.outbuf.clear();
+                            State::Crypting
+                        }
+                    }
+                }
+                State::Finalizing => {
+                    if this.inbuf.filled().len() == extract_tag_len {
+                        if extract_tag_len > 0 {
+                            // we extracted some tag, set it
+                            this.crypter.set_tag(this.inbuf.filled())?;
+                        }
+
+                        if buf.remaining() > block_size + append_tag_len {
+                            // readbuf is big enough, finalize directly into it
+                            let amt = this.crypter.finalize(buf.initialize_unfilled())?;
+                            buf.advance(amt);
+                            if append_tag_len > 0 {
+                                // we need to append a tag
+                                this.crypter.get_tag(&mut buf.initialize_unfilled()[..append_tag_len])?;
+                                buf.advance(append_tag_len);
+                            }
+                            State::Done
+                        } else {
+                            // readbuf is too small, finalize to outbuf then last flush
+                            let amt = this.crypter.finalize(this.outbuf.unfilled_mut())?;
+                            this.outbuf.advance(amt);
+                            if append_tag_len > 0 {
+                                // we need to append a tag
+                                this.crypter.get_tag(&mut this.outbuf.unfilled_mut()[..append_tag_len])?;
+                                this.outbuf.advance(append_tag_len);
+                            }
+                            // Important, flagging this flush as the last one
+                            *this.last_flush = true;
+                            State::Flushing
+                        }
+                    } else {
+                        // The final bytes in the buffer do not match extract_tag_len
+                        debug_assert!(this.inbuf.filled().len() < extract_tag_len);
+                        return Err(
+                            std::io::Error::new(
+                                std::io::ErrorKind::UnexpectedEof,
+                                "unable to read enough bytes for the required tag"
+                            )
+                        ).into();
+                    }
+                }
+                State::Done => State::Done
+            };
+
+            if let State::Done = *this.state {
+                return Poll::Ready(Ok(()));
+            }
+
+            if buf.remaining() == 0 {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+}
+
+#[pin_project]
+pub struct CrypterWriter<W> {
+    #[pin]
+    writer: W,
+    crypter: Crypter,
+    mode: Mode,
+    extract_tag_len: usize,
+    append_tag_len: usize,
+    block_size: usize,
+    buf: Buffer,
+    tag_buf: Buffer,
+    was_updated: bool,
+    finalized: bool,
+}
+
+impl<W> fmt::Debug for CrypterWriter<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CrypterWriter")
+            .field("block_size", &self.block_size)
+            .field("mode", &self.mode)
+            .field("was_updated", &self.was_updated)
+            .field("finalized", &self.finalized)
+            .finish()
+    }
+}
+
+
+#[async_trait::async_trait]
+impl<W: AsyncUpload + Send> AsyncUpload for CrypterWriter<W> {
+    async fn abort(&mut self) -> anyhow::Result<()> {
+        Ok(self.writer.abort().await?)
+    }
+}
+
+
+impl<W: AsyncWrite> CrypterWriter<W> {
+    pub fn new(writer: W, mode: Mode, material: &ContentCryptoMaterial) -> std::io::Result<Self> {
+        Self::with_capacity(writer, mode, material, 64 * 1024)
+    }
+
+    pub fn with_capacity(writer: W, mode: Mode, material: &ContentCryptoMaterial, capacity: usize) -> std::io::Result<Self> {
+        let ContentCryptoMaterial { scheme, cek, iv, aad, .. } = material;
+        let cipher = scheme.cipher();
+        let block_size = cipher.block_size();
+        let mut crypter = Crypter::new(cipher, mode.into(), cek, Some(iv))?;
+        let (extract_tag_len, append_tag_len) = match mode {
+            Mode::Encrypt => (0, scheme.tag_len()),
+            Mode::Decrypt => (scheme.tag_len(), 0)
+        };
+        if let Some(aad) = aad {
+            crypter.aad_update(aad)?;
+        }
+        Ok(Self {
+            writer,
+            crypter,
+            mode,
+            extract_tag_len,
+            append_tag_len,
+            block_size,
+            buf: Buffer::with_capacity(capacity),
+            tag_buf: Buffer::with_capacity(extract_tag_len * 2),
+            was_updated: false,
+            finalized: false
+        })
+    }
+
+    pub fn get_ref(&self) -> &W {
+        &self.writer
+    }
+
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
+
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut W> {
+        self.project().writer
+    }
+
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+
+    fn flush_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+
+        while this.buf.filled().len() > 0 {
+            match ready!(this.writer.as_mut().poll_write(cx, &this.buf.filled())) {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "failed to write the buffered data",
+                    )).into();
+                }
+                Ok(n) => this.buf.consume(n),
+                Err(e) => {
+                    return Err(e).into();
+                }
+            }
+        }
+
+        this.buf.clear();
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn finalize(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> std::io::Result<()> {
+        let this = self.project();
+        if *this.extract_tag_len > 0 {
+            if this.tag_buf.filled().len() == *this.extract_tag_len {
+                this.crypter.set_tag(this.tag_buf.filled())?;
+                this.tag_buf.consume(*this.extract_tag_len);
+            } else {
+                // The bytes in the tag buffer do not match extract_tag_len
+                debug_assert!(this.tag_buf.filled().len() < *this.extract_tag_len);
+                return Err(
+                    std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "not enough written bytes for the required tag"
+                    )
+                ).into();
+            }
+        }
+        let amt = this.crypter.finalize(this.buf.unfilled_mut())?;
+        this.buf.advance(amt);
+        if *this.append_tag_len > 0 {
+            this.crypter.get_tag(&mut this.buf.unfilled_mut()[..*this.append_tag_len])?;
+            this.buf.advance(*this.append_tag_len);
+        }
+        *this.finalized = true;
+        Ok(())
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for CrypterWriter<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let block_size = self.block_size;
+        let extract_tag_len = self.extract_tag_len;
+        // We will only write the amount that fits our buffer.
+        let upper_bound = buf.len().min(self.buf.capacity().saturating_sub(block_size));
+        let required_space = upper_bound + block_size;
+        // Truncate buffer to upper bound;
+        let buf = &buf[..upper_bound];
+        if self.buf.unfilled().len() < required_space {
+            ready!(self.as_mut().flush_buf(cx))?;
+        }
+
+        let this = self.project();
+
+        // Buffer last bytes without decrypting if we are expecting a tag
+        let last_bytes_offset = buf.len().saturating_sub(extract_tag_len);
+        let last = &buf[last_bytes_offset..];
+
+        if last.len() > 0 {
+            let overflow = (last.len() + this.tag_buf.filled().len()).saturating_sub(extract_tag_len);
+            if overflow > 0 {
+                // we have more bytes than extract_tag_len flush the excess to main buffer
+                debug_assert!(overflow <= last.len());
+                let amt = this.crypter.update(&this.tag_buf.filled()[..overflow], this.buf.unfilled_mut())?;
+                this.buf.advance(amt);
+                this.tag_buf.consume(overflow);
+                // crypter was updated, needs to be finalized
+                *this.was_updated = true;
+            }
+            this.tag_buf.compact();
+            this.tag_buf.put_slice(last);
+        }
+
+        // These bytes cannot be the tag, crypt them into main buffer
+        let first = &buf[..last_bytes_offset];
+        if first.len() > 0 {
+            let amt = this.crypter.update(first, this.buf.unfilled_mut())?;
+            this.buf.advance(amt);
+            // crypter was updated, needs to be finalized
+            *this.was_updated = true;
+        }
+        Poll::Ready(Ok(first.len() + last.len()))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        ready!(self.as_mut().flush_buf(cx))?;
+        self.get_pin_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        // crypter can only be finalized if it was updated at least once
+        if !self.finalized && self.was_updated {
+            if self.buf.unfilled().len() < self.block_size + self.append_tag_len {
+                ready!(self.as_mut().flush_buf(cx))?;
+            }
+            self.as_mut().finalize(cx)?;
+        }
+
+        ready!(self.as_mut().flush_buf(cx))?;
+        self.get_pin_mut().poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn crypter_reader_aes_cbc_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes128Cbc);
+
+        let mut reader = CrypterReader::new(data.as_slice(), Mode::Encrypt, &material).unwrap();
+        let mut ciphertext = vec![];
+        reader.read_to_end(&mut ciphertext).await.unwrap();
+
+        let mut reader = CrypterReader::new(ciphertext.as_slice(), Mode::Decrypt, &material).unwrap();
+        let mut plaintext = vec![];
+        reader.read_to_end(&mut plaintext).await.unwrap();
+        assert_eq!(data, plaintext);
+    }
+
+    #[tokio::test]
+    async fn crypter_reader_aes_gcm_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes256Gcm)
+            .with_aad(b"test aad".as_slice());
+
+        let mut reader = CrypterReader::new(data.as_slice(), Mode::Encrypt, &material).unwrap();
+        let mut ciphertext = vec![];
+        reader.read_to_end(&mut ciphertext).await.unwrap();
+
+        let mut reader = CrypterReader::new(ciphertext.as_slice(), Mode::Decrypt, &material).unwrap();
+        let mut plaintext = vec![];
+        reader.read_to_end(&mut plaintext).await.unwrap();
+        assert_eq!(data, plaintext);
+    }
+
+    #[tokio::test]
+    async fn crypter_writer_aes_cbc_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes128Cbc);
+
+        let mut ciphertext = vec![];
+        let mut writer = CrypterWriter::new(&mut ciphertext, Mode::Encrypt, &material).unwrap();
+        writer.write_all(&data).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        let mut plaintext = vec![];
+        let mut writer = CrypterWriter::new(&mut plaintext, Mode::Decrypt, &material).unwrap();
+        writer.write_all(&ciphertext).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+        assert_eq!(data, plaintext);
+    }
+
+    #[tokio::test]
+    async fn crypter_writer_aes_gcm_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes256Gcm)
+            .with_aad(b"test aad".as_slice());
+
+        let mut ciphertext = vec![];
+        let mut writer = CrypterWriter::new(&mut ciphertext, Mode::Encrypt, &material).unwrap();
+        writer.write_all(&data).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        let mut plaintext = vec![];
+        let mut writer = CrypterWriter::new(&mut plaintext, Mode::Decrypt, &material).unwrap();
+        writer.write_all(&ciphertext).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+        assert_eq!(data, plaintext);
+    }
+
+    #[tokio::test]
+    async fn crypter_writer_and_reader_aes_cbc_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes128Cbc);
+
+        let mut ciphertext = vec![];
+        let mut writer = CrypterWriter::new(&mut ciphertext, Mode::Encrypt, &material).unwrap();
+        writer.write_all(&data).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        let mut reader = CrypterReader::new(ciphertext.as_slice(), Mode::Decrypt, &material).unwrap();
+        let mut plaintext = vec![];
+        reader.read_to_end(&mut plaintext).await.unwrap();
+        assert_eq!(data, plaintext);
+    }
+
+    #[tokio::test]
+    async fn crypter_writer_and_reader_aes_gcm_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes256Gcm)
+            .with_aad(b"test aad".as_slice());
+
+        let mut ciphertext = vec![];
+        let mut writer = CrypterWriter::new(&mut ciphertext, Mode::Encrypt, &material).unwrap();
+        writer.write_all(&data).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        let mut reader = CrypterReader::new(ciphertext.as_slice(), Mode::Decrypt, &material).unwrap();
+        let mut plaintext = vec![];
+        reader.read_to_end(&mut plaintext).await.unwrap();
+        assert_eq!(data, plaintext);
+    }
+
+    #[tokio::test]
+    async fn crypter_reader_and_writer_aes_cbc_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes128Cbc);
+
+        let mut reader = CrypterReader::new(data.as_slice(), Mode::Encrypt, &material).unwrap();
+        let mut ciphertext = vec![];
+        reader.read_to_end(&mut ciphertext).await.unwrap();
+
+        let mut plaintext = vec![];
+        let mut writer = CrypterWriter::new(&mut plaintext, Mode::Decrypt, &material).unwrap();
+        writer.write_all(&ciphertext).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        assert_eq!(data, plaintext);
+    }
+
+    #[tokio::test]
+    async fn crypter_reader_and_writer_aes_gcm_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes256Gcm)
+            .with_aad(b"test aad".as_slice());
+
+        let mut reader = CrypterReader::new(data.as_slice(), Mode::Encrypt, &material).unwrap();
+        let mut ciphertext = vec![];
+        reader.read_to_end(&mut ciphertext).await.unwrap();
+
+        let mut plaintext = vec![];
+        let mut writer = CrypterWriter::new(&mut plaintext, Mode::Decrypt, &material).unwrap();
+        writer.write_all(&ciphertext).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        assert_eq!(data, plaintext);
+    }
+
+    #[test]
+    fn content_encryption_aes_cbc_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes128Cbc);
+
+        let ciphertext = encrypt(&data, &material).unwrap();
+
+        let plaintext = decrypt(&ciphertext, &material).unwrap();
+
+        assert_eq!(data, plaintext);
+    }
+
+    #[test]
+    fn content_encryption_aes_gcm_round_trip() {
+        let data: Vec<u8> = (0..100000u32).map(|n| (n % 256) as u8).collect();
+
+        let material = ContentCryptoMaterial::generate(CryptoScheme::Aes256Gcm)
+            .with_aad("AES/GCM/NoPadding");
+
+        let ciphertext = encrypt(&data, &material).unwrap();
+
+        let plaintext = decrypt(&ciphertext, &material).unwrap();
+
+        assert_eq!(data, plaintext);
+    }
+}

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -24,8 +24,8 @@ pub(crate) trait CryptoMaterialProvider:
     + Sync
     + Debug
     + 'static {
-    async fn material_for_write(&self, path: &str, data_len: Option<usize>) -> anyhow::Result<(ContentCryptoMaterial, Attributes)>;
-    async fn material_from_metadata(&self, path: &str, attr: &Attributes) -> anyhow::Result<ContentCryptoMaterial>;
+    async fn material_for_write(&self, path: &str, data_len: Option<usize>) -> crate::Result<(ContentCryptoMaterial, Attributes)>;
+    async fn material_from_metadata(&self, path: &str, attr: &Attributes) -> crate::Result<ContentCryptoMaterial>;
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -665,7 +665,7 @@ impl<W> fmt::Debug for CrypterWriter<W> {
 
 #[async_trait::async_trait]
 impl<W: AsyncUpload + Send> AsyncUpload for CrypterWriter<W> {
-    async fn abort(&mut self) -> anyhow::Result<()> {
+    async fn abort(&mut self) -> crate::Result<()> {
         Ok(self.writer.abort().await?)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -270,6 +270,13 @@ impl Kind {
                         retries,
                         reason: ErrorReason::Timeout
                     }
+                } else if e.kind() == std::io::ErrorKind::NotFound {
+                    if e.source().is_some() { continue; }
+                    // Do not retry root NotFound
+                    return ErrorInfo {
+                        retries,
+                        reason: ErrorReason::Unknown
+                    }
                 } else if e.kind() == std::io::ErrorKind::Other && e.source().is_some() {
                     // Continue to source error
                     continue

--- a/src/error.rs
+++ b/src/error.rs
@@ -196,30 +196,6 @@ pub enum Kind {
 }
 
 impl Kind {
-//     pub(crate) fn retryable(&self) -> bool {
-//         match self {
-//             Kind::Request(_)
-//             | Kind::InvalidResponse(_)
-//             | Kind::DeserializeResponse { .. } => {
-//                 true
-//             },
-//             Kind::StorageNotEncrypted(_)
-//             | Kind::InvalidConfig { .. }
-//             | Kind::RequiredConfig(_)
-//             | Kind::ErrorResponse(_)
-//             | Kind::NotImplemented(_) => {
-//                 false
-//             }
-//             Kind::Wrapped(e) => e.kind.retryable(),
-//             Kind::Context { source, .. } => {
-//                 match source.downcast_ref::<Error>() {
-//                     Some(e) => e.kind.retryable(),
-//                     None => false
-//                 }
-//             }
-//         }
-//     }
-
     pub(crate) fn chain(&self) -> Chain {
         Chain(Some(self))
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,6 +31,8 @@ metric_const!(total_put_ops);
 metric_const!(total_delete_ops);
 metric_const!(total_keyring_get);
 metric_const!(total_keyring_miss);
+metric_const!(total_fetch_upload_info);
+metric_const!(total_fetch_path_info);
 
 #[allow(dead_code)]
 pub fn init_metrics() {

--- a/src/snowflake/client.rs
+++ b/src/snowflake/client.rs
@@ -573,21 +573,21 @@ impl SnowflakeClient {
         }
     }
     pub(crate) async fn fetch_upload_info(&self, stage: impl AsRef<str>) -> crate::Result<SnowflakeUploadData> {
-        counter!("total_fetch_upload_info").increment(1);
         let _guard = duration_on_drop!(metrics::sf_fetch_upload_info_retried_duration);
         let upload_data: SnowflakeUploadData = self
             .query(format!("PUT file:///tmp/whatever @{}", stage.as_ref()))
             .await?;
 
+        counter!(metrics::total_fetch_upload_info).increment(1);
         Ok(upload_data)
     }
     pub(crate) async fn fetch_path_info(&self, stage: impl AsRef<str>, path: impl AsRef<str>) -> crate::Result<SnowflakeDownloadData> {
-        counter!("total_fetch_path_info").increment(1);
         let _guard = duration_on_drop!(metrics::sf_fetch_path_info_retried_duration);
         let download_data: SnowflakeDownloadData = self
             .query(format!("GET @{}/{} file:///tmp/whatever", stage.as_ref(), path.as_ref()))
             .await?;
 
+        counter!(metrics::total_fetch_path_info).increment(1);
         Ok(download_data)
     }
     #[allow(unused)]

--- a/src/snowflake/client.rs
+++ b/src/snowflake/client.rs
@@ -1,0 +1,559 @@
+use backoff::backoff::Backoff;
+use object_store::RetryConfig;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{collections::HashMap, sync::Arc, time::{Duration, Instant, SystemTime, UNIX_EPOCH}};
+use tokio::sync::Mutex;
+use zeroize::Zeroize;
+use moka::future::Cache;
+use crate::error::Error;
+use crate::util::{deserialize_str, deserialize_slice};
+// use anyhow::anyhow;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum SnowflakeResponse<T> {
+    Success {
+        data: T,
+        success: bool,
+    },
+    Error {
+        data: SnowflakeErrorData,
+        code: String,
+        message: String,
+        success: bool,
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SnowflakeTokenData {
+    session_token: String,
+    #[serde(rename = "validityInSecondsST")]
+    validity_in_seconds_st: u64,
+    master_token: String,
+    #[serde(rename = "validityInSecondsMT")]
+    validity_in_seconds_mt: u64
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SnowflakeLoginData {
+    token: String,
+    validity_in_seconds: u64,
+    master_token: String,
+    master_validity_in_seconds: u64
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SnowflakeColType {
+    name: String
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SnowflakeResultChunk {
+    url: String,
+    row_count: usize,
+    uncompressed_size: usize,
+    compressed_size: usize
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SnowflakeQueryData {
+    rowtype: Vec<SnowflakeColType>,
+    rowset: Vec<Vec<serde_json::Value>>,
+    total: usize,
+    returned: usize,
+    #[serde(default)]
+    chunk_headers: HashMap<String, String>,
+    #[serde(default)]
+    chunks: Vec<SnowflakeResultChunk>
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) struct SnowflakeStageCreds {
+    pub aws_key_id: String,
+    pub aws_secret_key: String,
+    pub aws_token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SnowflakeStageInfo {
+    pub location_type: String,
+    pub location: String,
+    pub path: String,
+    pub region: String,
+    pub storage_account: Option<String>,
+    pub is_client_side_encrypted: bool,
+    pub ciphers: Option<String>,
+    pub creds: SnowflakeStageCreds,
+    pub use_s3_regional_url: bool,
+    pub end_point: Option<String>
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone)]
+pub(crate) struct SnowflakeEncryptionMaterial {
+    pub query_stage_master_key: String,
+    pub query_id: String,
+    pub smk_id: u64,
+}
+
+impl Drop for SnowflakeEncryptionMaterial {
+    fn drop(&mut self) {
+        self.query_stage_master_key.zeroize();
+    }
+}
+
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SnowflakeUploadData {
+    pub query_id: String,
+    pub encryption_material: Option<SnowflakeEncryptionMaterial>,
+    pub stage_info: SnowflakeStageInfo,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SnowflakeDownloadData {
+    pub query_id: String,
+    #[serde(rename = "src_locations")]
+    pub src_locations: Vec<String>,
+    pub encryption_material: Vec<Option<SnowflakeEncryptionMaterial>>,
+    pub stage_info: SnowflakeStageInfo,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SnowflakeErrorData {
+    query_id: String
+}
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum SnowflakeQueryResponse {
+    Success {
+        data: SnowflakeQueryData,
+        success: bool,
+    },
+    Upload {
+        data: SnowflakeUploadData,
+        success: bool,
+    },
+    Download {
+        data: SnowflakeDownloadData,
+        success: bool,
+    },
+    Error {
+        data: SnowflakeErrorData,
+        code: String,
+        message: String,
+        success: bool,
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SnowflakeQueryStatus {
+    id: String,
+    status: String,
+    state: String,
+    error_code: Option<String>,
+    error_message: Option<String>
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SnowflakeStatusData {
+    queries: Vec<SnowflakeQueryStatus>
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SnowflakeStatusResponse {
+    data: SnowflakeStatusData
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SnowflakeClientConfig {
+    pub account: String,
+    pub database: String,
+    pub host: String,
+    pub schema: String,
+    pub warehouse: Option<String>,
+    pub retry_config: RetryConfig
+}
+
+impl SnowflakeClientConfig {
+    #[allow(unused)]
+    pub(crate) fn from_env() -> anyhow::Result<SnowflakeClientConfig> {
+        use std::env;
+        Ok(SnowflakeClientConfig {
+            account: env::var("SNOWFLAKE_ACCOUNT")?,
+            database: env::var("SNOWFLAKE_DATABASE")?,
+            host: env::var("SNOWFLAKE_HOST")?,
+            schema: env::var("SNOWFLAKE_SCHEMA")?,
+            warehouse: env::var("SNOWFLAKE_WAREHOUSE").ok(),
+            retry_config: RetryConfig::default()
+        })
+    }
+}
+
+struct TokenState {
+    token: String,
+    expiration: Instant,
+    master_token: String,
+    #[allow(unused)]
+    master_expiration: Instant
+}
+
+#[derive(Clone)]
+pub(crate) struct SnowflakeClient {
+    config: SnowflakeClientConfig,
+    client: reqwest::Client,
+    token: Arc<Mutex<Option<TokenState>>>,
+    stage_info_cache: Cache<String, Arc<SnowflakeUploadData>>
+}
+
+impl std::fmt::Debug for SnowflakeClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnowflakeClient")
+         .field("config", &self.config)
+         .finish()
+    }
+}
+
+impl SnowflakeClient {
+    pub(crate) fn new(config: SnowflakeClientConfig) -> Arc<SnowflakeClient> {
+        let client = SnowflakeClient {
+            config,
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(180))
+                .build().unwrap(),
+            token: Arc::new(Mutex::new(None)),
+            stage_info_cache: Cache::builder()
+                .max_capacity(10)
+                // Time to live here manages the stage token lifecycle, removing it from the cache
+                // prior to expiration
+                .time_to_live(std::time::Duration::from_secs(40 * 60))
+                .build()
+        };
+
+        let client = Arc::new(client);
+
+        {
+            let client = Arc::downgrade(&client);
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(5 * 60));
+                interval.tick().await;
+                loop {
+                    interval.tick().await;
+                    if let Some(client) = client.upgrade() {
+                        match client.heartbeat().await {
+                            Ok(_) => {},
+                            Err(e) => {
+                                tracing::warn!("Heartbeat failed: {:#}", e);
+                            }
+                        }
+                    } else {
+                        // Client was dropped, stop heartbeat
+                        break;
+                    }
+                }
+            });
+        }
+
+        client
+    }
+    #[allow(unused)]
+    pub(crate) fn from_env() -> anyhow::Result<Arc<SnowflakeClient>> {
+        Ok(SnowflakeClient::new(SnowflakeClientConfig::from_env()?))
+    }
+    async fn heartbeat(&self) -> anyhow::Result<bool> {
+        let token = {
+            let locked = self.token.lock().await;
+            match locked.as_ref() {
+                Some(TokenState { token, .. }) => token.clone(),
+                _ => {
+                    return Ok(false);
+                }
+            }
+        };
+
+        let response = self.client.post(format!("https://{}/session/heartbeat", self.config.host))
+            .header("Authorization", format!("Snowflake Token=\"{}\"", token))
+            .send()
+            .await?;
+
+        response.error_for_status_ref()?;
+
+        return Ok(true);
+    }
+    pub(crate) async fn token(&self) -> crate::Result<String> {
+        let mut locked = self.token.lock().await;
+        match locked.as_ref() {
+            Some(TokenState { token, expiration, .. }) if Instant::now() + Duration::from_secs(180) < *expiration => {
+                return Ok(token.clone());
+            }
+            _ => {}
+        }
+
+        let config = &self.config;
+
+        if let Some(TokenState { token, master_token, .. }) = locked.as_ref() {
+            // Renew
+            let response = self.client.post(format!("https://{}/session/token-request", config.host))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .header("Authorization", format!("Snowflake Token=\"{}\"", master_token))
+                .query(&[
+                    ("requestId", uuid::Uuid::new_v4().to_string())
+                ])
+                .json(&serde_json::json!({
+                    "oldSessionToken": token,
+                    "requestType": "RENEW"
+                }))
+                .send()
+                .await?;
+
+            response.error_for_status_ref()
+                .inspect_err(|_| *locked = None)?;
+
+            let token_response_bytes = response
+                .bytes()
+                .await
+                .inspect_err(|_| *locked = None)?;
+
+            let token_response: SnowflakeResponse<SnowflakeTokenData> = deserialize_slice(&token_response_bytes)
+                .map_err(Error::deserialize_response_err("token"))
+                .inspect_err(|_| *locked = None)?;
+
+            match token_response {
+                SnowflakeResponse::Success { data, .. } => {
+                    *locked = Some(TokenState {
+                        token: data.session_token.clone(),
+                        expiration: Instant::now() + Duration::from_secs(data.validity_in_seconds_st),
+                        master_token: data.master_token,
+                        master_expiration: Instant::now() + Duration::from_secs(data.validity_in_seconds_mt)
+                    });
+
+                    return Ok(data.session_token);
+
+                }
+                SnowflakeResponse::Error { data, code, message, .. } => {
+                    *locked = None;
+                    return Err(Error::error_response(format!("Error (code: {}, query_id: {}): {}", code, data.query_id, message)).into())
+                }
+            }
+        } else {
+            // Login
+            let master_token = std::fs::read_to_string(std::env::var("MASTER_TOKEN_PATH").unwrap_or("/snowflake/session/token".into()))
+                .map_err(Error::invalid_config_err("Unable to access master token file"))?;
+
+            let mut qs = vec![
+                ("accountName", &config.account),
+                ("databaseName", &config.database),
+                ("schemaName", &config.schema),
+            ];
+
+            if let Some(warehouse) = config.warehouse.as_ref() {
+                qs.push(("warehouse", warehouse));
+            }
+
+            let response = self.client.post(format!("https://{}/session/v1/login-request", config.host))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/snowflake")
+                .query(&qs)
+                .json(&serde_json::json!({
+                    "data": {
+                        "ACCOUNT_NAME": &config.account,
+                        "TOKEN": &master_token,
+                        "AUTHENTICATOR": "OAUTH"
+                    }
+                }))
+                .send()
+                .await?;
+
+            response.error_for_status_ref()?;
+
+            let login_response_bytes = response
+                .bytes()
+                .await?;
+
+            let login_response: SnowflakeResponse<SnowflakeLoginData> = deserialize_slice(&login_response_bytes)
+                .map_err(Error::deserialize_response_err("login"))?;
+
+            match login_response {
+                SnowflakeResponse::Success { data, .. } => {
+                    *locked = Some(TokenState {
+                        token: data.token.clone(),
+                        expiration: Instant::now() + Duration::from_secs(data.validity_in_seconds),
+                        master_token: data.master_token,
+                        master_expiration: Instant::now() + Duration::from_secs(data.master_validity_in_seconds)
+                    });
+
+                    return Ok(data.token);
+
+                }
+                SnowflakeResponse::Error { data, code, message, .. } => {
+                    return Err(Error::error_response(format!("Error (code: {}, query_id: {}): {}", code, data.query_id, message)).into())
+                }
+            }
+        }
+    }
+    async fn query_impl<T: DeserializeOwned>(&self, query: impl AsRef<str>) -> crate::Result<SnowflakeResponse<T>> {
+        let token = self.token().await?;
+        let config = &self.config;
+        let response = self.client.post(format!("https://{}/queries/v1/query-request", config.host))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("Authorization", format!("Snowflake Token=\"{}\"", token))
+            .query(&[
+                ("clientStartTime", SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs().to_string()),
+                ("requestId", uuid::Uuid::new_v4().to_string()),
+                ("request_guid", uuid::Uuid::new_v4().to_string())
+            ])
+            .json(&serde_json::json!({
+                "sqlText": query.as_ref(),
+                "asyncExec": false,
+                "sequenceId": 1,
+                "isInternal": false
+            }))
+            .send()
+            .await?;
+
+        response.error_for_status_ref()?;
+
+        // TODO: directly to Deserialize
+        let response_string = response
+            .text()
+            .await?;
+
+        let response = deserialize_str(&response_string)
+            .map_err(Error::deserialize_response_err("query"))?;
+
+        Ok(response)
+    }
+
+    async fn query<T: DeserializeOwned>(&self, query: impl AsRef<str>) -> crate::Result<SnowflakeResponse<T>> {
+        let mut backoff = backoff::ExponentialBackoff {
+            initial_interval: self.config.retry_config.backoff.init_backoff,
+            max_interval: self.config.retry_config.backoff.max_backoff,
+            max_elapsed_time: Some(self.config.retry_config.retry_timeout),
+            ..Default::default()
+        };
+        let max_retries = self.config.retry_config.max_retries;
+        let mut retries = 0;
+        loop {
+            match self.query_impl(query.as_ref()).await {
+                Ok(success @ SnowflakeResponse::Success { .. }) => {
+                    return Ok(success)
+                }
+                Ok(SnowflakeResponse::Error { data, code, message, success }) => {
+                    match (backoff.next_backoff(), retries < max_retries) {
+                        (Some(duration), true) => {
+                            tracing::warn!(
+                                "retrying snowflake query error: Error (code: {}, query_id: {}): {}",
+                                code, data.query_id, message
+                            );
+                            retries += 1;
+                            tokio::time::sleep(duration).await;
+                            continue;
+                        }
+                        _ => {
+                            return Ok(SnowflakeResponse::Error { data, code, message, success });
+                        }
+                    }
+                }
+                Err(e) => {
+                    match (backoff.next_backoff(), retries < max_retries &&  e.retryable()) {
+                        (Some(duration), true) => {
+                            tracing::warn!("retrying snowflake query due to: {}", e);
+                            retries += 1;
+                            tokio::time::sleep(duration).await;
+                            continue;
+                        }
+                        _ => {
+                            return Err(e)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    pub(crate) async fn fetch_upload_info(&self, stage: impl AsRef<str>) -> crate::Result<SnowflakeUploadData> {
+        let response: SnowflakeResponse<SnowflakeUploadData> = self
+            .query(format!("PUT file:///tmp/whatever @{}", stage.as_ref()))
+            .await?;
+
+        match response {
+            SnowflakeResponse::Success { data, .. } => {
+                Ok(data)
+            }
+            SnowflakeResponse::Error { message, code, data, .. } => {
+                if code == "333334" {
+                    tracing::error!("unexpected async execution response for query {} while fetching upload info", data.query_id);
+                }
+                return Err(Error::error_response(format!("Error (code: {}, query_id: {}): {}", code, data.query_id, message)).into())
+            }
+        }
+    }
+    pub(crate) async fn fetch_path_info(&self, stage: impl AsRef<str>, path: impl AsRef<str>) -> crate::Result<SnowflakeDownloadData> {
+        let response: SnowflakeResponse<SnowflakeDownloadData> = self
+            .query(format!("GET @{}/{} file:///tmp/whatever", stage.as_ref(), path.as_ref()))
+            .await?;
+
+        match response {
+            SnowflakeResponse::Success { data, .. } => {
+                Ok(data)
+            }
+            SnowflakeResponse::Error { message, code, data, .. } => {
+                if code == "333334" {
+                    tracing::error!("unexpected async execution response for query {} while fetching path info", data.query_id);
+                }
+                return Err(Error::error_response(format!("Error (code: {}, query_id: {}): {}", code, data.query_id, message)).into())
+            }
+        }
+    }
+    #[allow(unused)]
+    pub(crate) async fn get_presigned_url(&self, stage: impl AsRef<str>, path: impl AsRef<str>) -> crate::Result<String> {
+        let response: SnowflakeResponse<SnowflakeQueryData> = self
+            .query(format!("SELECT get_presigned_url(@{}, '{}')", stage.as_ref(), path.as_ref()))
+            .await?;
+
+        match response {
+            SnowflakeResponse::Success { data, .. } => {
+                let url = data.rowset
+                    .get(0)
+                    .and_then(|r| r.get(0))
+                    .and_then(|c| c.as_str())
+                    .ok_or_else(|| Error::invalid_response("Missing url from get_presigned_url response"))?;
+                Ok(url.to_string())
+            }
+            SnowflakeResponse::Error { message, code, data, .. } => {
+                if code == "333334" {
+                    tracing::error!("unexpected async execution response for query {} while fetching path info", data.query_id);
+                }
+                return Err(Error::error_response(format!("Error (code: {}, query_id: {}): {}", code, data.query_id, message)).into())
+            }
+        }
+    }
+    pub(crate) async fn current_upload_info(&self, stage: impl AsRef<str>) -> crate::Result<Arc<SnowflakeUploadData>> {
+        let stage = stage.as_ref();
+        let stage_info = self.stage_info_cache.try_get_with_by_ref(stage, async {
+            let info = self.fetch_upload_info(stage).await?;
+
+            // TODO schedule task to update token before deadline
+            Ok::<_, Error>(Arc::new(info))
+        }).await?;
+        Ok(stage_info)
+    }
+}
+
+
+

--- a/src/snowflake/kms.rs
+++ b/src/snowflake/kms.rs
@@ -149,7 +149,6 @@ impl CryptoMaterialProvider for SnowflakeStageKms {
                 .ok_or_else(|| "src locations and encryption material length mismatch")?
                 .ok_or_else(|| "path not encrypted")?;
 
-            println!("enc_material {:?}", encryption_material);
             let master_key = Key::from_base64(&encryption_material.query_stage_master_key)
                 .map_err(|e| format!("failed to decode qsmk base64: {}", e))?;
             Ok::<_, ErrorMessage>(master_key)

--- a/src/snowflake/kms.rs
+++ b/src/snowflake/kms.rs
@@ -28,7 +28,10 @@ impl Default for SnowflakeStageKmsConfig {
         SnowflakeStageKmsConfig {
             crypto_scheme: CryptoScheme::Aes128Cbc,
             keyring_capacity: 100_000,
-            keyring_ttl: std::time::Duration::from_secs(40 * 60)
+            // We keep the ttl at 10 minutes to preserve the SF TSS guarantee
+            // that data cannot be decrypted after this period if the customer
+            // revokes the customer key
+            keyring_ttl: std::time::Duration::from_secs(10 * 60)
         }
     }
 }

--- a/src/snowflake/kms.rs
+++ b/src/snowflake/kms.rs
@@ -1,0 +1,183 @@
+use crate::{snowflake::SnowflakeClient, encryption::{CryptoMaterialProvider, CryptoScheme, ContentCryptoMaterial, Key, EncryptedKey, Iv}};
+
+use serde::{Serialize, Deserialize};
+use object_store::{Attributes, Attribute, AttributeValue};
+use anyhow::anyhow;
+use moka::future::Cache;
+use std::sync::Arc;
+
+type ErrorMessage = String;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MaterialDescription {
+    pub smk_id: String,
+    pub query_id: String,
+    pub key_size: String
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SnowflakeStageKmsConfig {
+    pub crypto_scheme: CryptoScheme,
+    pub keyring_capacity: usize,
+    pub keyring_ttl: std::time::Duration
+}
+
+impl Default for SnowflakeStageKmsConfig {
+    fn default() -> Self {
+        SnowflakeStageKmsConfig {
+            crypto_scheme: CryptoScheme::Aes128Cbc,
+            keyring_capacity: 100_000,
+            keyring_ttl: std::time::Duration::from_secs(40 * 60)
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SnowflakeStageKms {
+    client: Arc<SnowflakeClient>,
+    stage: String,
+    prefix: String,
+    config: SnowflakeStageKmsConfig,
+    keyring: Cache<String, Key>
+}
+
+impl std::fmt::Debug for SnowflakeStageKms {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnowflakeStageKms")
+         .field("client", &self.client)
+         .field("stage", &self.stage)
+         .field("config", &self.config)
+         .field("keyring", &"redacted")
+         .finish()
+    }
+}
+
+impl SnowflakeStageKms {
+    pub(crate) fn new(
+        client: Arc<SnowflakeClient>,
+        stage: impl Into<String>,
+        prefix: impl Into<String>,
+        config: SnowflakeStageKmsConfig
+    ) -> SnowflakeStageKms {
+        SnowflakeStageKms {
+            client,
+            stage: stage.into(),
+            prefix: prefix.into(),
+            keyring: Cache::builder()
+                .max_capacity(config.keyring_capacity as u64)
+                .time_to_live(config.keyring_ttl)
+                .build(),
+            config
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CryptoMaterialProvider for SnowflakeStageKms {
+    async fn material_for_write(&self, _path: &str, data_len: Option<usize>) -> anyhow::Result<(ContentCryptoMaterial, Attributes)> {
+        let info = self.client.current_upload_info(&self.stage).await?;
+
+        let encryption_material = info.encryption_material.as_ref()
+            .ok_or_else(|| anyhow!("stage `{}` not encrypted", self.stage))?;
+        let description = MaterialDescription {
+            smk_id: encryption_material.smk_id.to_string(),
+            query_id: encryption_material.query_id.clone(),
+            key_size: "128".to_string()
+        };
+        let master_key = Key::from_base64(&encryption_material.query_stage_master_key)?;
+
+        let scheme = self.config.crypto_scheme;
+        let mut material = ContentCryptoMaterial::generate(scheme);
+        let encrypted_cek = material.cek.clone().encrypt_aes_128_ecb(&master_key)?;
+
+        let mut attributes = Attributes::new();
+        attributes.insert(
+            Attribute::Metadata("x-amz-key".into()),
+            AttributeValue::from(encrypted_cek.as_base64())
+        );
+        attributes.insert(
+            Attribute::Metadata("x-amz-iv".into()),
+            AttributeValue::from(material.iv.as_base64())
+        );
+        if let Some(data_len) = data_len {
+            attributes.insert(
+                Attribute::Metadata("x-amz-unencrypted-content-length".into()),
+                AttributeValue::from(format!("{}", data_len))
+            );
+        }
+        attributes.insert(
+            Attribute::Metadata("x-amz-matdesc".into()),
+            AttributeValue::from(serde_json::to_string(&description)?)
+        );
+
+        let cek_alg = match scheme {
+            CryptoScheme::Aes256Gcm => {
+                let cek_alg = "AES/GCM/NoPadding";
+                material = material.with_aad(cek_alg);
+                cek_alg
+            },
+            CryptoScheme::Aes128Cbc => "AES/CBC/PKCS5Padding"
+        };
+
+        attributes.insert(
+            Attribute::Metadata("x-amz-cek-alg".into()),
+            AttributeValue::from(cek_alg)
+        );
+
+        Ok((material, attributes))
+    }
+
+    async fn material_from_metadata(&self, path: &str, attr: &Attributes) -> anyhow::Result<ContentCryptoMaterial> {
+        let path = path.strip_prefix(&self.prefix).unwrap_or(path);
+        let required_attribute = |key: &'static str| {
+            let v: &str = attr.get(&Attribute::Metadata(key.into()))
+                .ok_or_else(|| anyhow!("missing required attribute `{}`", key))?
+                .as_ref();
+            Ok::<_, anyhow::Error>(v)
+        };
+
+
+        let material_description: MaterialDescription = serde_json::from_str(required_attribute("x-amz-matdesc")?)?;
+        let master_key = self.keyring.try_get_with(material_description.query_id, async {
+            let info = self.client.fetch_path_info(&self.stage, path).await
+                .map_err(|e| format!("failed to fetch path info: {}", e))?;
+            let position = info.src_locations.iter().position(|l| l == path)
+                .ok_or_else(|| "path not found")?;
+            let encryption_material = info.encryption_material.get(position)
+                .cloned()
+                .ok_or_else(|| "src locations and encryption material length mismatch")?
+                .ok_or_else(|| "path not encrypted")?;
+
+            println!("enc_material {:?}", encryption_material);
+            let master_key = Key::from_base64(&encryption_material.query_stage_master_key)
+                .map_err(|e| format!("failed to decode qsmk base64: {}", e))?;
+            Ok::<_, ErrorMessage>(master_key)
+        }).await.map_err(|e| anyhow!(Arc::unwrap_or_clone(e)))?;
+
+        let cek = EncryptedKey::from_base64(required_attribute("x-amz-key")?)?;
+        let cek = cek.decrypt_aes_128_ecb(&master_key)?;
+        let iv = Iv::from_base64(required_attribute("x-amz-iv")?)?;
+        let alg = required_attribute("x-amz-cek-alg");
+
+        let scheme = match alg {
+            Ok("AES/GCM/NoPadding") => CryptoScheme::Aes256Gcm,
+            Ok("AES/CBC/PKCS5Padding") | Err(_) => CryptoScheme::Aes128Cbc,
+            Ok(v) => unimplemented!("cek alg `{}` not implemented", v)
+        };
+
+        let aad = match alg {
+            Ok("AES/GCM/NoPadding") => Some("AES/GCM/NoPadding".into()),
+            _ => None
+        };
+
+        let content_material = ContentCryptoMaterial {
+            scheme,
+            cek,
+            iv,
+            aad
+        };
+
+        Ok(content_material)
+    }
+}

--- a/src/snowflake/mod.rs
+++ b/src/snowflake/mod.rs
@@ -1,0 +1,161 @@
+use crate::{encryption::{CryptoMaterialProvider, CryptoScheme}, error::Error};
+
+pub(crate) mod client;
+use client::{SnowflakeClient, SnowflakeClientConfig};
+
+pub(crate) mod kms;
+use kms::{SnowflakeStageKms, SnowflakeStageKmsConfig};
+
+use object_store::{ObjectStore, RetryConfig};
+use tokio::sync::Mutex;
+use std::sync::Arc;
+
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub(crate) struct S3StageCredentialProvider {
+    stage: String,
+    client: Arc<SnowflakeClient>,
+    cached: Mutex<Option<Arc<object_store::aws::AwsCredential>>>
+}
+
+impl S3StageCredentialProvider {
+    pub(crate) fn new(stage: impl AsRef<str>, client: Arc<SnowflakeClient>) -> S3StageCredentialProvider {
+        S3StageCredentialProvider { stage: stage.as_ref().to_string(), client, cached: Mutex::new(None) }
+    }
+}
+
+#[async_trait::async_trait]
+impl object_store::CredentialProvider for S3StageCredentialProvider {
+    type Credential = object_store::aws::AwsCredential;
+    async fn get_credential(&self) ->  object_store::Result<Arc<Self::Credential>> {
+        let info = self.client.current_upload_info(&self.stage).await
+            .map_err(|e| {
+                object_store::Error::Generic {
+                    store: "S3",
+                    source: e.into()
+                }
+            })?;
+
+        let mut locked = self.cached.lock().await;
+
+        match locked.as_ref() {
+            Some(creds) => if creds.key_id == info.stage_info.creds.aws_key_id {
+                return Ok(Arc::clone(creds));
+            }
+            _ => {}
+        }
+
+        let creds = Arc::new(object_store::aws::AwsCredential {
+            key_id: info.stage_info.creds.aws_key_id.clone(),
+            secret_key: info.stage_info.creds.aws_secret_key.clone(),
+            token: Some(info.stage_info.creds.aws_token.clone())
+        });
+
+        *locked = Some(Arc::clone(&creds));
+
+        Ok(creds)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SnowflakeConfig {
+    pub stage: String,
+    pub client_config: SnowflakeClientConfig,
+    pub kms_config: Option<SnowflakeStageKmsConfig>
+}
+
+pub(crate) fn validate_config_for_snowflake(mut map: HashMap<String, String>, retry_config: RetryConfig) -> anyhow::Result<SnowflakeConfig> {
+    let mut required_or_env = |field: &str| {
+        map
+            .remove(field)
+            .or(std::env::var(field.to_uppercase()).ok())
+            .ok_or_else(|| {
+                Error::required_config(field)
+            })
+    };
+
+    let client_config = SnowflakeClientConfig {
+        account: required_or_env("snowflake_account")?,
+        database: required_or_env("snowflake_database")?,
+        host: required_or_env("snowflake_host")?,
+        schema: required_or_env("snowflake_schema")?,
+        warehouse: map.remove("snowflake_warehouse").or(std::env::var("SNOWFLAKE_WAREHOUSE").ok()),
+        retry_config
+    };
+
+    let kms_config = if let Some(scheme_str) = map.remove("snowflake_encryption_scheme") {
+        Some(SnowflakeStageKmsConfig {
+           crypto_scheme: match scheme_str.as_str() {
+                "AES_256_GCM" => CryptoScheme::Aes256Gcm,
+                "AES_128_CBC" => CryptoScheme::Aes128Cbc,
+                _ => return Err(Error::invalid_config("Invalid value for snowflake_encryption_scheme").into()),
+           },
+           keyring_capacity: match map.remove("snowflake_keyring_capacity").map(|s| s.parse::<usize>()) {
+               Some(Ok(cap)) => cap,
+               Some(Err(e)) => return Err(Error::invalid_config_src("Failed to parse `snowflake_keyring_capacity`", e).into()),
+               None => Default::default()
+           },
+           keyring_ttl: match map.remove("snowflake_keyring_ttl_secs").map(|s| s.parse::<u64>()) {
+               Some(Ok(secs)) => std::time::Duration::from_secs(secs),
+               Some(Err(e)) => return Err(Error::invalid_config_src("Failed to parse `snowflake_keyring_ttl_secs`", e).into()),
+               None => Default::default()
+           }
+        })
+    } else {
+        None
+    };
+
+    let config = SnowflakeConfig {
+        stage: map.remove("snowflake_stage")
+            .ok_or_else(|| Error::required_config("snowflake_stage"))?,
+        client_config,
+        kms_config
+    };
+
+    for (key, _value) in map {
+        return Err(Error::invalid_config(format!("Unknown config `{key}` found while validating snowflake config")).into());
+    }
+
+    Ok(config)
+}
+
+pub(crate) async fn build_store_for_snowflake_stage(config_map: HashMap<String, String>, retry_config: RetryConfig) -> anyhow::Result<(Arc<dyn ObjectStore>, Option<Arc<dyn CryptoMaterialProvider>>, String)> {
+    let config = validate_config_for_snowflake(config_map, retry_config.clone())?;
+    let client = SnowflakeClient::new(config.client_config);
+    let info = client.current_upload_info(&config.stage).await?;
+
+    match info.stage_info.location_type.as_ref() {
+        "S3" => {
+            let (bucket, stage_prefix) = info.stage_info.location.split_once('/')
+                .ok_or_else(|| Error::invalid_response("Stage information from snowflake is missing the bucket name"))?;
+
+            let provider = S3StageCredentialProvider::new(&config.stage, client.clone());
+            let store = object_store::aws::AmazonS3Builder::default()
+                .with_region(info.stage_info.region.clone())
+                .with_bucket_name(bucket)
+                .with_credentials(Arc::new(provider))
+                .with_virtual_hosted_style_request(true)
+                .with_unsigned_payload(true)
+                .with_retry(retry_config)
+                .build()?;
+
+            if config.kms_config.is_some() && !info.stage_info.is_client_side_encrypted {
+                return Err(Error::StorageNotEncrypted(config.stage.clone()).into());
+            }
+
+            let crypto_material_provider = if info.stage_info.is_client_side_encrypted {
+                let kms_config = config.kms_config.unwrap_or_default();
+                let stage_kms = SnowflakeStageKms::new(client, &config.stage, stage_prefix, kms_config);
+                Some::<Arc<dyn CryptoMaterialProvider>>(Arc::new(stage_kms))
+            } else {
+                None
+            };
+
+            Ok((Arc::new(store), crypto_material_provider, stage_prefix.to_string()))
+        }
+        _ => {
+            unimplemented!("unknown stage location type");
+        }
+    }
+}


### PR DESCRIPTION
This PR consolidates all changes on the Rust side for supporting Snowflake internal stages as a first class store.
It also restructures much of the code (with many misc changes) to ensure the encryption functionality could be introduced in a generic way.